### PR TITLE
Add CI-driven app version injection and deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy Production
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve and inject app version
+        run: scripts/inject-app-version.sh index.html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -526,7 +526,7 @@ const suitClass = { "♠":"spades", "♥":"hearts", "♦":"diamonds", "♣":"clu
 
 const SUIT_STYLE_KEY = "rs_suitStyle_v1";
 const GAME_STATE_KEY = "rs_gameState_v1";
-const APP_VERSION = "v1.0.0 (local, 2026-02-21)";
+const APP_VERSION = "__APP_VERSION__";
 
 function applySuitStyle(style){
   const clsPrefix = "suit-style-";

--- a/scripts/inject-app-version.sh
+++ b/scripts/inject-app-version.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_FILE="${1:-index.html}"
+PLACEHOLDER="__APP_VERSION__"
+
+if [[ ! -f "$TARGET_FILE" ]]; then
+  echo "Target file not found: $TARGET_FILE" >&2
+  exit 1
+fi
+
+build_date="${BUILD_DATE:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}" 
+
+if [[ -n "${GITHUB_REF_TYPE:-}" && "${GITHUB_REF_TYPE}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+  version_base="${GITHUB_REF_NAME}"
+elif [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
+  version_base="${GITHUB_REF#refs/tags/}"
+elif git describe --tags --exact-match >/dev/null 2>&1; then
+  version_base="$(git describe --tags --exact-match)"
+else
+  version_base="dev"
+fi
+
+if [[ -n "${GITHUB_SHA:-}" ]]; then
+  commit_sha="${GITHUB_SHA}"
+elif git rev-parse --verify HEAD >/dev/null 2>&1; then
+  commit_sha="$(git rev-parse HEAD)"
+else
+  commit_sha="unknown"
+fi
+short_sha="${commit_sha:0:7}"
+
+resolved_version="${version_base}+${short_sha} (${build_date})"
+
+if ! rg -q "$PLACEHOLDER" "$TARGET_FILE"; then
+  echo "Placeholder '$PLACEHOLDER' not found in $TARGET_FILE" >&2
+  exit 1
+fi
+
+python3 - "$TARGET_FILE" "$PLACEHOLDER" "$resolved_version" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+placeholder = sys.argv[2]
+resolved = sys.argv[3]
+content = path.read_text(encoding="utf-8")
+path.write_text(content.replace(placeholder, resolved), encoding="utf-8")
+PY
+
+echo "Injected app version into ${TARGET_FILE}: ${resolved_version}"


### PR DESCRIPTION
### Motivation
- Replace the hardcoded app version in `index.html` with a deploy-time placeholder so builds can stamp an authoritative value at release time.
- Ensure the client-side `renderAppVersion()` continues to read a resolved value at runtime from the same `APP_VERSION` symbol and the existing `<span id="appVersion"></span>` anchor.
- Compute a reproducible version string from CI/git context (tag if present, short commit SHA, UTC build date) to make production builds traceable.

### Description
- Replaced the hardcoded `const APP_VERSION =

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f3073a94832fa60a36d7cc2964a9)