### PR TITLE
fix(ci): replace rg placeholder check with grep

### DIFF
--- a/scripts/inject-app-version.sh
+++ b/scripts/inject-app-version.sh
@@ -32,7 +32,7 @@ short_sha="${commit_sha:0:7}"
 
 resolved_version="${version_base}+${short_sha} (${build_date})"
 
-if ! rg -q "$PLACEHOLDER" "$TARGET_FILE"; then
+if ! grep -q "$PLACEHOLDER" "$TARGET_FILE"; then
   echo "Placeholder '$PLACEHOLDER' not found in $TARGET_FILE" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- update `scripts/inject-app-version.sh` to use `grep -q` instead of `rg -q` when verifying the `__APP_VERSION__` placeholder exists
- remove the Cloudflare Pages dependency on ripgrep so the version injection script can run in the default Pages build environment

## Validation
- `rg -n "grep -q|rg -q" scripts/inject-app-version.sh`
- `bash -n scripts/inject-app-version.sh`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f4acc250832f92e981cbce927572)