### PR TITLE
Add run counters and persistent game statistics UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,6 +698,7 @@ function startTimer(){
     elapsedMs += now - lastTickTs;
     lastTickTs = now;
     updateRunStatsUI();
+    persistGameState();
   }, 1000);
 }
 
@@ -926,6 +927,10 @@ function showHint(){
   alert("No suggestions found.");
 }
 
+function canFinalizeLoss(){
+  return historyStack.length === 0;
+}
+
 /* --- GAME STATE CHECKS --- */
 function checkGameState(){
   if(isWin()){
@@ -935,7 +940,7 @@ function checkGameState(){
   } else {
     // Check for loss (no moves possible)
     if(!findAnyMove(false)){
-      recordGameResult('loss');
+      if(canFinalizeLoss()) recordGameResult('loss');
       document.getElementById('modalLose').classList.add('active');
     }
   }
@@ -1357,7 +1362,7 @@ document.getElementById("newGameBtn").onclick = start;
 document.getElementById("undoBtn").onclick = undo;
 document.getElementById("autoBtn").onclick = autoPlay;
 document.getElementById("giveUpBtn").onclick = () => {
-  recordGameResult('loss');
+  if(canFinalizeLoss()) recordGameResult('loss');
   document.getElementById('modalLose').classList.add('active');
 };
 document.getElementById("statsBtn").onclick = () => {


### PR DESCRIPTION
### Motivation
- Track per-run metrics (moves, elapsed time, undos) so players can see live progress during a game. 
- Persist per-run counters with the game snapshot and append completed-game results to a separate bounded history so aggregate stats can be computed later. 
- Expose aggregate statistics (total games, win rate, current/best streak, avg moves/time on wins) in a small modal and provide a `Reset stats` action. 

### Description
- Added a compact live run-stats bar under the header with HTML/CSS and a new `Stats` header button that opens a stats modal. 
- Introduced JS state variables `moveCount`, `undoCount`, `elapsedMs`, `timerInterval`, and `gameFinished`, plus `STATS_HISTORY_KEY`/`MAX_STATS_HISTORY` to store a bounded `localStorage` history. 
- Implemented timer and helpers (`startTimer`, `resetRunStats`, `updateRunStatsUI`, `formatDuration`), persistence of the counters in the game snapshot, and recording of results via `recordGameResult`. 
- Wired counters into move/undo flows and end-of-game paths (`win`, `loss`, `Give Up`), added `renderStatsModal`/`computeStats`, and hooked `Reset Stats`/open/close handlers. 

### Testing
- Served the app with `python -m http.server --directory /workspace/rezanow-site` and exercised the UI with Playwright to open the page and click `#statsBtn`, which succeeded and produced a screenshot of the stats modal. 
- An initial background `python -m http.server` attempt returned `ERR_EMPTY_RESPONSE` in the environment but was retried and the server successfully served the app for the Playwright run. 
- No unit tests were added; the changes were validated via the browser automation run (Playwright) which confirmed the modal renders and the `Stats` button is functional.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a0931ee88832f9eaf4f9915919a1e)