### PR TITLE
ci: install ripgrep before app version injection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+
       - name: Resolve and inject app version
         run: scripts/inject-app-version.sh index.html
 


### PR DESCRIPTION
## Summary
- add a workflow step to install `ripgrep` on the GitHub Actions runner
- run installation before `scripts/inject-app-version.sh index.html`

## Why
The deploy job calls `rg` inside `scripts/inject-app-version.sh`. On runners where `ripgrep` is missing, the step fails. Installing `ripgrep` in the workflow ensures the script can execute reliably.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a17e54420832f87e670ccaedfb5f3)