### PR TITLE
Fix missing mobile label for double-click foundation toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,6 +260,7 @@ width: 100%;
 
     @media (max-width: 420px){
       .suit-style-label{ display:none; }
+      .dblclick-foundation-label{ display:inline-block; font-size: 11px; }
       #suitStyleSelect{ max-width: 140px; padding: 0 6px; }
     }
 
@@ -473,7 +474,7 @@ header .controls > *{ flex: 0 0 auto; }
         <option value="cb">Colorblind-Safe</option>
       </select>
 
-      <label class="suit-style-label" for="doubleClickFoundationToggle">Double-click to Foundation</label>
+      <label class="suit-style-label dblclick-foundation-label" for="doubleClickFoundationToggle">Double-click to Foundation</label>
       <input id="doubleClickFoundationToggle" type="checkbox" title="Double-click a top card or free-cell card to move it to a valid foundation" />
 
       


### PR DESCRIPTION
## Summary
- keep the `Double-click to Foundation` label visible on narrow screens
- add a dedicated `.dblclick-foundation-label` class and mobile override so only the suit-style label is hidden
- apply the new class to the double-click foundation label in the header controls

## Validation
- confirmed the HTML/CSS diff updates only the affected label and media query
- captured a mobile viewport screenshot showing the label is visible next to the toggle

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1b70760c832f8bc6416773805bee)