### PR TITLE
ci: set v0.1.0 fallback for development version strings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           else
             BASE_TAG="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
             if [[ -z "$BASE_TAG" ]]; then
-              BASE_TAG="v0.0.0"
+              BASE_TAG="v0.1.0"
             fi
             APP_VERSION="${BASE_TAG}-dev+${SHORT_SHA}"
           fi

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -68,4 +68,4 @@ For branches that are not configured for official releases, CI injects a develop
 vX.Y.Z-dev+<shortsha>
 ```
 
-Where `X.Y.Z` is derived from the latest reachable tag (or `0.0.0` when no tag exists), and `<shortsha>` is the current short commit SHA.
+Where `X.Y.Z` is derived from the latest reachable tag (or baseline `0.1.0` when no tag exists yet in checkout scope), and `<shortsha>` is the current short commit SHA.


### PR DESCRIPTION
### Motivation
- Ensure non-release builds resolve to a sensible baseline version string (`v0.1.0-dev+<shortsha>`) when no reachable tag exists in the checkout scope.
- Make the documented versioning fallback policy consistent with the runtime behavior used by CI footer injection.
- Establish an initial annotated tag `v0.1.0` at the current production-ready merge commit so development builds can derive a baseline tag.

### Description
- Update the release workflow to use `v0.1.0` as the fallback base tag in `build-versioned-footer` by changing `BASE_TAG` default in `.github/workflows/release.yml`.
- Align the `VERSIONING.md` fallback wording to reference the `0.1.0` baseline when no tag is present.
- Create an annotated tag `v0.1.0` locally pointing at the current production-ready merge commit (`7d454e8`).

### Testing
- Ran the workflow resolution logic with: `SHORT_SHA="$(git rev-parse --short=7 HEAD)"; BASE_TAG="$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || true)"; if [[ -z "$BASE_TAG" ]]; then BASE_TAG="v0.1.0"; fi; echo "${BASE_TAG}-dev+${SHORT_SHA}"` and it resolved to `v0.1.0-dev+<shortsha>`, confirming the new fallback behavior (success).
- Verified the annotated tag exists with: `git show v0.1.0 --no-patch --pretty=fuller`, which confirmed the tag metadata and target commit (success).
- Attempted to push the tag with: `git push origin v0.1.0`, but the push failed in this environment due to a network/proxy restriction (`CONNECT tunnel failed, response 403`) so the tag was not pushed to the remote from this runner (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1f03d09c832f9426cf13174398ed)