### PR TITLE
ci: enforce baseline semantic tag on main pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Ensure semantic version baseline tag exists on main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin main
+
+          if ! git tag --merged origin/main --list 'v*' | grep -q .; then
+            echo "::error::No v* tag found on main. Create initial tag v0.1.0 to establish semantic baseline."
+            exit 1
+          fi
+
       - name: Validate commit messages
         uses: wagoid/commitlint-github-action@v6
         with:


### PR DESCRIPTION
### Motivation
- Prevent main branch push workflows from silently falling back to an implicit `v0.0.0` by making sure a semantic `v*` tag exists as a baseline, while keeping feature branch builds unaffected.

### Description
- Add a pre-step to the `commitlint` job that is scoped to `push` events on `refs/heads/main` which runs `git fetch --force --tags origin main` and checks `git tag --merged origin/main --list 'v*'`, failing with a clear actionable message and non-zero exit if no tag is found.

### Testing
- No automated CI tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a230836ec832f97c046df80a6835a)