### PR TITLE
Add responsive hamburger menu for header controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,15 +423,18 @@ header .controls > *{ flex: 0 0 auto; }
     overflow: hidden;
     max-height: 0;
     opacity: 0;
+    visibility: hidden;
     transform: translateY(-4px);
     pointer-events: none;
-    transition: max-height 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
+    transition: max-height 0.2s ease, opacity 0.2s ease, transform 0.2s ease, visibility 0s linear 0.2s;
   }
   header.menu-open .controls{
     max-height: 260px;
     opacity: 1;
+    visibility: visible;
     transform: translateY(0);
     pointer-events: auto;
+    transition-delay: 0s;
   }
   header .controls button,
   header .controls select{
@@ -1532,10 +1535,26 @@ const menuToggleBtn = document.getElementById('menuToggle');
 const headerControlsEl = document.getElementById('headerControls');
 const mobileMenuQuery = window.matchMedia('(max-width: 520px)');
 
+function syncMenuAccessibility(){
+  if(!headerControlsEl) return;
+  const shouldHideControls = mobileMenuQuery.matches && !headerEl.classList.contains('menu-open');
+  headerControlsEl.toggleAttribute('inert', shouldHideControls);
+  headerControlsEl.setAttribute('aria-hidden', String(shouldHideControls));
+}
+
 function setMenuOpen(isOpen){
   if(!headerEl || !menuToggleBtn || !headerControlsEl) return;
   headerEl.classList.toggle('menu-open', isOpen);
   menuToggleBtn.setAttribute('aria-expanded', String(isOpen));
+  syncMenuAccessibility();
+}
+
+function syncMenuForViewport(){
+  if(!mobileMenuQuery.matches){
+    headerEl.classList.remove('menu-open');
+    menuToggleBtn.setAttribute('aria-expanded', 'false');
+  }
+  syncMenuAccessibility();
 }
 
 if(menuToggleBtn){
@@ -1556,11 +1575,14 @@ if(menuToggleBtn){
   });
 });
 
+syncMenuForViewport();
+
 window.addEventListener('resize', () => {
-  if(!mobileMenuQuery.matches){
-    setMenuOpen(false);
-  }
+  syncMenuForViewport();
 });
+if(mobileMenuQuery.addEventListener){
+  mobileMenuQuery.addEventListener('change', syncMenuForViewport);
+}
 
 // Rules modal behavior
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
### Motivation
- Make the header controls usable on narrow screens by collapsing them behind a hamburger toggle while preserving the desktop layout and safe-area padding.
- Provide an accessible toggle that reveals the existing control set without changing existing control IDs or breaking current handlers.
- Ensure the layout recalculates correctly when the menu opens/closes so the play area never hides behind a wrapped header.

### Description
- Added a hamburger toggle button `#menuToggle` next to the title and wrapped existing controls in a container with `id="headerControls"`, keeping all original IDs (for example `hintBtn`, `newGameBtn`, `undoBtn`, etc.) unchanged.
- Introduced responsive CSS that keeps controls visible on larger viewports and hides them by default on mobile (`@media (max-width: 520px)`), revealing them when `header` has the `menu-open` class; added transition-safe `max-height`/`opacity` animations and retained safe-area padding using existing CSS variables.
- Implemented JS to toggle `header.menu-open`, keep `aria-expanded` in sync on `#menuToggle`, and set `aria-controls` to the controls container for accessibility.
- Added optional auto-close behavior that closes the menu on narrow screens after primary actions (`newGameBtn`, `undoBtn`, `autoBtn`, `hintBtn`, `giveUpBtn`) are clicked and calls `scheduleFit()` to recompute layout when the menu state changes.

### Testing
- Ran `git diff --check` to verify there were no whitespace issues and reported no problems.
- Launched a local HTTP server for preview and used Playwright to capture mobile screenshots showing the menu closed and open states, which were produced successfully.
- Verified the existing control event handlers continue to run (menu open/close does not replace or remove existing `onclick`/`onclick`-wired behavior) during the interactive checks; automated captures succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a2ad13e50832fb5f34d09a24b6a50)