### PR TITLE
ci: pass resolved footer version into injection step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
           echo "Resolved APP_VERSION=${APP_VERSION}"
 
       - name: Inject app version into footer build artifact
+        env:
+          APP_VERSION_TAG: ${{ steps.version.outputs.app_version }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
### Motivation

- Ensure the footer-injection step consumes the already-resolved release version to avoid rediscovering tags or falling back when `release_created == true`, while keeping only `build/index.html` as the modified artifact.

### Description

- Set `env: APP_VERSION_TAG: ${{ steps.version.outputs.app_version }}` on the `Inject app version into footer build artifact` step so the script receives the resolved value. 
- Left the `scripts/inject-app-version.sh` invocation unchanged so the script reads the provided `APP_VERSION_TAG` instead of recomputing discovery logic. 
- Kept `build/index.html` as the only artifact path created and uploaded by the job.

### Testing

- Inspected the workflow diff with `git diff -- .github/workflows/release.yml` to confirm only the environment addition was made and it succeeded. 
- Committed the change with `git commit -m "ci: pass resolved footer version into injection step"` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a31e06f24832f851c1ab3f3d6e5dd)