### PR TITLE
Fix unbalanced CSS brace in index stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,6 @@ width: 100%;
       --suit-bg-clubs: #e8f5e9;    /* light green */
     }
     /* Slightly smaller label on narrow screens */
-    }
 
   
 /* Suit style control */


### PR DESCRIPTION
### Motivation
- Remove a stray standalone `}` that left an unbalanced CSS block near the suit style controls so rule scoping and parsing are correct.

### Description
- Deleted the orphan `}` between the `/* Suit background color accessibility toggle */` and `/* Slightly smaller label on narrow screens */` comments in `index.html`, keeping the `:root` variables block and the following `.suit-style-label`, `#suitStyleSelect`, and `@media (max-width: 420px)` rules unchanged.

### Testing
- Inspected the file region with `sed -n '236,320p' index.html`, compared changes with `git diff -- index.html`, and rechecked line-numbered output with `nl -ba index.html | sed -n '238,296p'` to verify the brace was removed and surrounding rules remain intact; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a31e15844832f8023938d4cc42e0a)