### PR TITLE
Fix duplicate header structure and unify mobile menu wiring

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,9 +459,6 @@ header .controls > *{ flex: 0 0 auto; }
     justify-content: center;
   }
   header .controls{ flex: 1 1 100%; }
-  header[data-menu-open="false"] .controls {
-    display: none;
-  }
   header .controls button,
   header .controls select{
     height: 28px;
@@ -526,10 +523,6 @@ header .controls > *{ flex: 0 0 auto; }
 </style>
 </head>
 <body class="suit-style-normal">
-  <header data-menu-open="true">
-    <h1>Build-By-Suit Solitaire</h1>
-    <button id="menuToggle" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="controlsPanel">☰</button>
-    <div class="controls" id="controlsPanel">
   <header>
     <div class="header-main">
       <h1>Build-By-Suit Solitaire</h1>
@@ -1559,43 +1552,6 @@ renderStatsModal();
 initSuitStyleUI();
 initDoubleClickFoundationUI();
 renderAppVersion();
-initMenuToggle();
-
-function initMenuToggle(){
-  const header = document.querySelector('header');
-  const menuToggle = document.getElementById('menuToggle');
-  if(!header || !menuToggle) return;
-
-  const mobileQuery = window.matchMedia('(max-width: 520px)');
-
-  function setMenuState(isOpen){
-    header.dataset.menuOpen = String(isOpen);
-    menuToggle.setAttribute('aria-expanded', String(isOpen));
-    menuToggle.setAttribute('aria-label', isOpen ? 'Close menu' : 'Open menu');
-  }
-
-  function syncWithViewport(){
-    setMenuState(!mobileQuery.matches);
-  }
-
-  menuToggle.addEventListener('click', () => {
-    const isOpen = menuToggle.getAttribute('aria-expanded') === 'true';
-    setMenuState(!isOpen);
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if(event.key !== 'Escape') return;
-    const isMobile = mobileQuery.matches;
-    const isOpen = menuToggle.getAttribute('aria-expanded') === 'true';
-    if(isMobile && isOpen){
-      setMenuState(false);
-      menuToggle.focus();
-    }
-  });
-
-  mobileQuery.addEventListener('change', syncWithViewport);
-  syncWithViewport();
-}
 
 const headerEl = document.querySelector('header');
 const menuToggleBtn = document.getElementById('menuToggle');


### PR DESCRIPTION
### Motivation
- Remove a duplicated nested `<header>` branch that caused duplicated controls, duplicated IDs, and conflicting mobile menu state.
- Ensure a single accessible header with one title, one hamburger toggle, and one controls container so DOM IDs and ARIA attributes are unambiguous.
- Simplify the menu behavior so JavaScript selectors and CSS only target the surviving header/menu elements.

### Description
- Deleted the duplicated nested header block and left a single `<header>` containing one `<h1>Build-By-Suit Solitaire</h1>`, one hamburger button with `id="menuToggle"`, and one controls container with `id="headerControls"`.
- Updated the hamburger `aria-controls` to point to `headerControls` and removed the obsolete `controlsPanel` usage and the `data-menu-open` attribute reliance in markup and CSS.
- Removed the legacy `initMenuToggle()` function and aligned JavaScript to use the unified selectors `header`, `menuToggle` (via `getElementById('menuToggle')`), and `headerControls` (via `getElementById('headerControls')`) with a single `menu-open` class toggle for mobile behavior.
- Cleaned up CSS rules that referenced the old `data-menu-open` pattern so responsive behavior is consistent with the remaining header structure.

### Testing
- Searched the file to confirm only one `<header>`, one `menuToggle` ID, and one `headerControls` ID remain using `rg`/search, and the searches returned the expected single occurrences (success).
- Verified references to `controlsPanel`, `data-menu-open`, and `initMenuToggle` are removed using project-wide search commands (success).
- Launched a temporary HTTP server with `python -m http.server 4173 --bind 0.0.0.0` and captured a rendering screenshot via Playwright to validate the header renders and menu toggle is present (succeeded and screenshot produced).
- Ran basic runtime smoke checks (DOM queries and event wiring in the updated script) by loading the page and confirming existing JS selectors (`document.querySelector('header')`, `getElementById('menuToggle')`, `getElementById('headerControls')`) resolve (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a373cf258832faf604f050aafd95b)