### PR TITLE
fix(version): use v0.1.0 fallback when no tags exist

### DIFF
--- a/scripts/inject-app-version.sh
+++ b/scripts/inject-app-version.sh
@@ -32,7 +32,7 @@ resolve_version() {
     version_base="$(git describe --tags --abbrev=0 --match '[0-9]*' 2>/dev/null || true)"
   fi
   if [[ -z "${version_base}" ]]; then
-    version_base="v0.0.0"
+    version_base="v0.1.0"
   fi
 
   if [[ -n "${GITHUB_SHA:-}" ]]; then


### PR DESCRIPTION
## Summary
- update `scripts/inject-app-version.sh` to use `v0.1.0` (instead of `v0.0.0`) when no semantic tag is present
- keeps footer version output aligned with the release workflow guidance to establish `v0.1.0` as the initial baseline

## Why
The site footer showed `v0.0.0-dev+<sha>` in repos without tags, while CI guidance expects an initial semantic baseline at `v0.1.0`.

## Validation
- Ran: `scripts/inject-app-version.sh index.html resolve-only`
- Observed output: `v0.1.0-dev+55fae28`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4027e264832f8b7580ce0de77f1d)