### PR TITLE
Restore full run state on undo and prevent duplicate result recordings

### DIFF
--- a/index.html
+++ b/index.html
@@ -731,6 +731,7 @@ let elapsedMs=0;
 let timerInterval=null;
 let lastTickTs=Date.now();
 let gameFinished=false;
+let runResultRecorded=false;
 let doubleClickToFoundationEnabled=true;
 
 const MAX_PERSISTED_HISTORY = 150;
@@ -745,7 +746,8 @@ function persistGameState(){
     moveCount,
     undoCount,
     elapsedMs,
-    gameFinished
+    gameFinished,
+    runResultRecorded
   };
 
   // Browsers have strict localStorage quotas; if persistence fails, trim
@@ -775,6 +777,7 @@ function loadPersistedGameState(){
     undoCount = Number.isFinite(parsed.undoCount) ? parsed.undoCount : 0;
     elapsedMs = Number.isFinite(parsed.elapsedMs) ? parsed.elapsedMs : 0;
     gameFinished = !!parsed.gameFinished;
+    runResultRecorded = !!parsed.runResultRecorded;
     selected = null;
     return true;
   } catch(e){
@@ -817,6 +820,7 @@ function resetRunStats(){
   undoCount = 0;
   elapsedMs = 0;
   gameFinished = false;
+  runResultRecorded = false;
   lastTickTs = Date.now();
   updateRunStatsUI();
 }
@@ -837,8 +841,9 @@ function saveStatsHistory(history){
 }
 
 function recordGameResult(outcome){
-  if(gameFinished) return;
+  if(gameFinished || runResultRecorded) return;
   gameFinished = true;
+  runResultRecorded = true;
   const history = loadStatsHistory();
   history.push({ outcome, moveCount, undoCount, elapsedMs, finishedAt: Date.now() });
   saveStatsHistory(history);
@@ -896,7 +901,16 @@ function shuffle(a){ for(let i=a.length-1;i>0;i--){const j=Math.floor(Math.rando
 
 function save(){
   // Save snapshot of current state (used as a "pre-move" history entry).
-  historyStack.push(JSON.stringify({tableau, foundations, hand}));
+  historyStack.push(JSON.stringify({
+    tableau,
+    foundations,
+    hand,
+    moveCount,
+    undoCount,
+    elapsedMs,
+    gameFinished,
+    runResultRecorded
+  }));
 }
 function undo(){
   closeModals();
@@ -908,8 +922,14 @@ function undo(){
     tableau = prev.tableau;
     foundations = prev.foundations;
     hand = prev.hand;
+    moveCount = Number.isFinite(prev.moveCount) ? prev.moveCount : moveCount;
+    undoCount = Number.isFinite(prev.undoCount) ? prev.undoCount : undoCount;
+    elapsedMs = Number.isFinite(prev.elapsedMs) ? prev.elapsedMs : elapsedMs;
+    gameFinished = typeof prev.gameFinished === 'boolean' ? prev.gameFinished : false;
+    runResultRecorded = typeof prev.runResultRecorded === 'boolean' ? prev.runResultRecorded : false;
     selected = null;
     undoCount++;
+    lastTickTs = Date.now();
     persistGameState();
     updateRunStatsUI();
     fit(); render();


### PR DESCRIPTION
### Motivation
- Undo should fully restore run state (including finished flag, counters, and elapsed time) so resuming after an undo behaves correctly and the timer restarts when appropriate. 
- Win/loss recording must be idempotent so results are not double-counted when users undo/resume across end-of-run modals.

### Description
- Add a `runResultRecorded` boolean to the runtime/persisted snapshot to act as an idempotency guard for result recording and include it in `persistGameState()`/load paths. 
- Expand `save()` snapshots to include `moveCount`, `undoCount`, `elapsedMs`, `gameFinished`, and `runResultRecorded` so history entries are full run-state snapshots. 
- Update `undo()` to restore `moveCount`, `undoCount`, `elapsedMs`, `gameFinished`, and `runResultRecorded` from the popped snapshot, reset `lastTickTs` to rebase the timer, then persist and refresh the UI. 
- Harden `recordGameResult()` to return early when a result already recorded by this run is detected and reset the guard in `resetRunStats()` for fresh runs.

### Testing
- Located and inspected relevant functions/fields with `rg -n` to verify all affected symbols are updated and consistent. 
- Reviewed the changed snapshot contents and the undo/load flows by printing the updated file region (`nl -ba` / selective sed output) to confirm correct restoration order. 
- Applied the patch successfully and verified the resulting source diff to ensure no malformed JS blocks were introduced; no automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4301255c832f965903567aa2dbec)