### PR TITLE
Record loss on explicit Give Up for active runs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1541,7 +1541,7 @@ document.getElementById("newGameBtn").onclick = start;
 document.getElementById("undoBtn").onclick = undo;
 document.getElementById("autoBtn").onclick = autoPlay;
 document.getElementById("giveUpBtn").onclick = () => {
-  if(canFinalizeLoss()) recordGameResult('loss');
+  if(hasActiveRunToRecordAsLoss() && !runResultRecorded) recordGameResult('loss');
   document.getElementById('modalLose').classList.add('active');
 };
 document.getElementById("statsBtn").onclick = () => {


### PR DESCRIPTION
### Motivation
- Ensure an explicit surrender via the Give Up button always records a loss for an active run while preventing duplicate recordings and leaving automatic no-move detection unchanged.

### Description
- Update the `giveUpBtn` click handler to call `recordGameResult('loss')` when `hasActiveRunToRecordAsLoss() && !runResultRecorded`, while keeping `canFinalizeLoss()` behavior intact and preserving the existing `modalLose` presentation.

### Testing
- Applied the change to `index.html`, verified the patch and file diff, and confirmed via pattern searches that `hasActiveRunToRecordAsLoss`, `canFinalizeLoss`, and the updated `giveUpBtn` handler are present and correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a442e1ca8832f9d5a9ca68f705547)