### PR TITLE
fix(versioning): align docs and script fallback version format

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -68,4 +68,13 @@ For branches that are not configured for official releases, CI injects a develop
 vX.Y.Z-dev+<shortsha>
 ```
 
-Where `X.Y.Z` is derived from the latest reachable `v*` tag (or baseline `0.0.0` only when no matching tag exists in checkout scope), and `<shortsha>` is the current short commit SHA.
+Where `X.Y.Z` is derived from the latest reachable tag in this order:
+
+1. latest reachable `v*` tag,
+2. latest reachable unprefixed numeric tag (`X.Y.Z`), normalized to `vX.Y.Z`,
+3. baseline `v0.0.0` when no matching tag exists in checkout scope.
+
+Examples:
+- `v1.4.2-dev+abc1234` (latest reachable tag is `v1.4.2`)
+- `v2.0.1-dev+abc1234` (latest reachable tag is `2.0.1`, normalized with `v` prefix)
+- `v0.0.0-dev+abc1234` (no reachable release tags)

--- a/scripts/inject-app-version.sh
+++ b/scripts/inject-app-version.sh
@@ -6,6 +6,10 @@ MODE="${2:-inject}"
 PLACEHOLDER="__APP_VERSION__"
 
 resolve_version() {
+  # Precedence:
+  # 1) APP_VERSION_TAG (explicit override)
+  # 2) GitHub tag refs from workflow context (release tags)
+  # 3) Derived development fallback from latest reachable tag + short SHA
   local version_base
   local commit_sha
   local short_sha
@@ -30,9 +34,12 @@ resolve_version() {
   version_base="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
   if [[ -z "${version_base}" ]]; then
     version_base="$(git describe --tags --abbrev=0 --match '[0-9]*' 2>/dev/null || true)"
+    if [[ -n "${version_base}" ]]; then
+      version_base="v${version_base}"
+    fi
   fi
   if [[ -z "${version_base}" ]]; then
-    version_base="v0.1.0"
+    version_base="v0.0.0"
   fi
 
   if [[ -n "${GITHUB_SHA:-}" ]]; then


### PR DESCRIPTION
### Motivation
- Resolve mismatch between `VERSIONING.md` and `scripts/inject-app-version.sh` so documented and generated no-tag fallback strings are identical.
- Ensure prefix conventions are consistent by normalizing unprefixed numeric tags to a `v`-prefixed baseline in generated dev strings.
- Make version-resolution precedence explicit so overrides and CI/GitHub contexts behave predictably.

### Description
- Added an inline precedence note to `resolve_version()` documenting the order: `APP_VERSION_TAG` override, GitHub tag refs, then derived fallback.
- When `git describe` finds an unprefixed numeric tag (`X.Y.Z`) the script now normalizes it to `vX.Y.Z` before producing the dev fallback string.
- Changed the no-tag baseline from `v0.1.0` to `v0.0.0` to match the documented baseline policy and produce `v0.0.0-dev+<shortsha>` when no tags exist.
- Updated `VERSIONING.md` fallback section to enumerate the lookup order and include exact examples that mirror script output (`vX.Y.Z-dev+<shortsha>`).

### Testing
- Ran `bash scripts/inject-app-version.sh /tmp/nonexistent resolve-only` and it returned a dev fallback in `v0.0.0-dev+<shortsha>` format (succeeded).
- Ran `APP_VERSION_TAG=v9.9.9 bash scripts/inject-app-version.sh /tmp/nonexistent resolve-only` and it returned `v9.9.9` to confirm the explicit override precedence (succeeded).
- Ran `GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.2.3 bash scripts/inject-app-version.sh /tmp/nonexistent resolve-only` and it returned `v1.2.3` to confirm GitHub tag ref precedence (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4544b4a8832f8f663cfef3a3ac94)