### PR TITLE
Keep mobile menu open when using Hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -1620,7 +1620,7 @@ document.addEventListener('keydown', (event) => {
   menuToggleBtn?.focus();
 });
 
-['newGameBtn', 'undoBtn', 'autoBtn', 'hintBtn', 'giveUpBtn'].forEach((id) => {
+['newGameBtn', 'undoBtn', 'autoBtn', 'giveUpBtn'].forEach((id) => {
   const actionBtn = document.getElementById(id);
   if(!actionBtn) return;
   actionBtn.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Tapping the `Hint` button on mobile could immediately collapse the header menu and trigger a re-fit/render, which made hint highlighting appear to not work or be inconsistent, so the menu should remain open when invoking hints.

### Description
- Removed `hintBtn` from the auto-close handler array in `index.html` so the `Hint` action (`showHint()`) does not automatically collapse the mobile header menu.

### Testing
- Verified the change with `git diff` and `rg` to confirm `hintBtn` was removed from the `['newGameBtn', 'undoBtn', 'autoBtn', 'giveUpBtn']` handler, applied the patch (`apply_patch`) and committed the change (`git commit`) successfully, and checked repository status; an attempted external web search via `curl` failed with HTTP 403 but all local verification commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4c4973cc832fa898c2c75c9144bd)