### PR TITLE
Prevent Undo from auto-closing mobile action menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -1620,7 +1620,7 @@ document.addEventListener('keydown', (event) => {
   menuToggleBtn?.focus();
 });
 
-['newGameBtn', 'undoBtn', 'autoBtn', 'giveUpBtn'].forEach((id) => {
+['newGameBtn', 'autoBtn', 'giveUpBtn'].forEach((id) => {
   const actionBtn = document.getElementById(id);
   if(!actionBtn) return;
   actionBtn.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Prevent the Undo action from closing the mobile action menu so users can undo without the menu being dismissed.

### Description
- Removed `undoBtn` from the auto-close ID array in `index.html` so only `newGameBtn`, `autoBtn`, and `giveUpBtn` call `setMenuOpen(false)` on mobile.

### Testing
- Ran `rg` checks and inspected the handler region with `nl -ba index.html | sed -n '1618,1632p'`, verified `undoBtn` is no longer in the auto-close list, and validated repository state with `git status` before committing the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5034118c832f8635e94cc1f742e7)