### PR TITLE
Adjust tableau hint logic for king-to-empty fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1143,27 +1143,37 @@ function findAnyMove(highlight){
     }
   }
   // 4. Pile -> Tableau (Deep moves allowed)
-  for(let i=0; i<7; i++){
-    const p = tableau[i];
-    for(let j=0; j<p.length; j++){
-      if(!p[j].faceUp) continue;
-      const c = p[j];
-      for(let t=0; t<7; t++){
-        if(i===t) continue;
-        const tp = tableau[t];
-        if(!tp.length){ 
-           if(c.rank==='K' && j>0){ // Don't move King from base to empty
-             if(highlight) { highlightPileCard(i,j,'source'); highlightPile(t,'target'); }
-             return true; 
-           } 
-        }
-        else if(canTableau(c, tp[tp.length-1])){ 
-           if(highlight) { highlightPileCard(i,j,'source'); highlightPileCard(t, tp.length-1, 'target'); }
-           return true; 
+  // Prefer stronger progress first; if none exist, allow king-to-empty fallback moves.
+  const findPileToTableauMove = (allowBaseKingToEmpty) => {
+    for(let i=0; i<7; i++){
+      const p = tableau[i];
+      for(let j=0; j<p.length; j++){
+        if(!p[j].faceUp) continue;
+        const c = p[j];
+        for(let t=0; t<7; t++){
+          if(i===t) continue;
+          const tp = tableau[t];
+          if(!tp.length){
+            const movingKingToEmpty = c.rank === 'K' && (allowBaseKingToEmpty || j > 0);
+            if(movingKingToEmpty){
+              if(highlight) { highlightPileCard(i,j,'source'); highlightPile(t,'target'); }
+              return true;
+            }
+          }
+          else if(canTableau(c, tp[tp.length-1])){
+            if(highlight) { highlightPileCard(i,j,'source'); highlightPileCard(t, tp.length-1, 'target'); }
+            return true;
+          }
         }
       }
     }
-  }
+    return false;
+  };
+
+  // Pass 1: stronger progress only (no base king -> empty pile moves).
+  if(findPileToTableauMove(false)) return true;
+  // Pass 2: fallback includes any legal king-led run to empty, including j === 0.
+  if(findPileToTableauMove(true)) return true;
   // 5. Pile Top -> Hand (Only if Hand slot empty)
   for(let h=0; h<3; h++){
       if(!hand[h]){


### PR DESCRIPTION
### Motivation
- The existing hint logic in `findAnyMove(highlight)` excluded moving a king-led run from a pile base to an empty tableau by hard-checking `j > 0`, which prevented legal base-king moves under the ruleset. 
- The intent is to allow such moves when they are legal while still deprioritizing them compared to stronger progress moves. 
- Highlight behavior must remain unchanged when a move is chosen.

### Description
- Replaced the single-loop `// 4. Pile -> Tableau (Deep moves allowed)` block with a helper `findPileToTableauMove(allowBaseKingToEmpty)` that scans pile-to-tableau moves with a parameterized allowance for base-king-to-empty moves. 
- Implemented a two-pass ranking: first call `findPileToTableauMove(false)` to prefer stronger progress and exclude base-king-to-empty, then call `findPileToTableauMove(true)` as a fallback to permit legal king-led runs from `j === 0`. 
- Preserved existing highlight calls (`highlightPileCard(..., 'source')`, `highlightPile(..., 'target')`, and `highlightPileCard(..., 'target')`) exactly where a move is returned.

### Testing
- The patch was applied successfully to `index.html` and the updated function flow was reviewed to verify the two-pass behavior executes as intended. 
- No automated unit or integration tests exist for this file, so no test suite was run; the change is localized to hint-selection logic and prepared for manual/playtesting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a50505d60832f8e3b7041299adb96)