### PR TITLE
docs(versioning): clarify when semantic version bumps are created

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -60,6 +60,25 @@ CI release automation is configured to:
 3. Create/update Git tag and GitHub release.
 4. Export the resolved version string to the build-injection step that stamps the footer version placeholder in `index.html`.
 
+> **Important:** Semantic version bumps (tag/release creation) are performed **only** by the GitHub Actions workflow at `.github/workflows/release.yml`, in the `release` job, and only on `push` events to `main` (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`).
+
+## Why my PR didn’t bump version
+
+If your pull request did not create a new version tag or GitHub Release, this is expected behavior in most cases:
+
+1. **PRs themselves do not create tags/releases.**
+   The `release` job is gated to run only after changes are merged and pushed to `main`, not on `pull_request` events.
+2. **Version increments are computed after merge on `main`.**
+   Release automation evaluates Conventional Commits from the merged history on `main` and then calculates the next semantic version.
+3. **Merge strategy and commit format still matter.**
+   Use a merge approach that preserves Conventional Commit messages in `main` history (for example, squash commit title/body or individual commits) and ensure commit messages satisfy the required format:
+
+   ```text
+   <type>(optional-scope): <short description>
+   ```
+
+   Release-driving types remain `feat` (MINOR), `fix`/`perf` (PATCH), and any breaking change marker (`!` or `BREAKING CHANGE:`) for MAJOR.
+
 ## Fallback for Non-Release Branches
 
 For branches that are not configured for official releases, CI injects a development version string:


### PR DESCRIPTION
### Motivation

- Reduce confusion about why pull requests do not create version tags or GitHub Releases by documenting the release job's scope. 
- Make it explicit that semantic version bumps are produced only by CI after changes land on `main` to guide contributor expectations and merge practices.

### Description

- Updated `VERSIONING.md` to add an important note that semantic version bumps (tag/release creation) are performed only by the GitHub Actions workflow at `.github/workflows/release.yml` in the `release` job and only on `push` to `main` (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`).
- Added a `Why my PR didn’t bump version` section explaining that PRs do not create tags/releases, that version increments are computed after merge on `main`, and that merge strategy and Conventional Commit formatting must preserve conventional commit messages for release detection. 
- Restated the required commit message format (`<type>(optional-scope): <short description>`) and which commit types drive `MAJOR`, `MINOR`, and `PATCH` releases.

### Testing

- Ran `git diff -- VERSIONING.md` to verify the intended changes are present, which succeeded. 
- Ran `nl -ba VERSIONING.md | sed -n '52,110p'` to inspect the new section in-context, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6b59b29c832f9edbe76ce2776282)