### PR TITLE
fix(ci): bootstrap missing v* baseline tag on main and validate release-please outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,10 @@ jobs:
           git fetch --force --tags origin main
 
           if ! git tag --merged origin/main --list 'v*' | grep -q .; then
-            echo "::error::No v* tag found on main. Create initial tag v0.1.0 to establish semantic baseline."
-            exit 1
+            BASELINE_TAG="v0.1.0"
+            echo "No reachable v* tag found on origin/main. Creating baseline ${BASELINE_TAG}."
+            git tag -a "${BASELINE_TAG}" origin/main -m "chore(release): bootstrap ${BASELINE_TAG}"
+            git push origin "${BASELINE_TAG}"
           fi
 
       - name: Validate commit messages
@@ -51,6 +53,33 @@ jobs:
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Validate release-please outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RELEASE_CREATED='${{ steps.release.outputs.release_created }}'
+          TAG_NAME='${{ steps.release.outputs.tag_name }}'
+
+          if [[ "${RELEASE_CREATED}" != "true" && "${RELEASE_CREATED}" != "false" ]]; then
+            echo "::error::release_created output is missing or invalid: ${RELEASE_CREATED}"
+            exit 1
+          fi
+
+          if [[ "${RELEASE_CREATED}" == "true" ]]; then
+            if [[ -z "${TAG_NAME}" ]]; then
+              echo "::error::tag_name output is empty while release_created=true"
+              exit 1
+            fi
+            if [[ ! "${TAG_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::tag_name is not a semantic v* tag: ${TAG_NAME}"
+              exit 1
+            fi
+          fi
+
+          echo "release_created=${RELEASE_CREATED}"
+          echo "tag_name=${TAG_NAME}"
 
   build-versioned-footer:
     name: build-with-version-footer


### PR DESCRIPTION
### Motivation
- Ensure repositories without an initial semantic `v*` tag can bootstrap a baseline so release tooling runs on `main` instead of failing CI. 
- Make `release-please` behavior explicit and fail-fast by validating `release_created` and `tag_name` outputs so downstream steps get a reliable version string.

### Description
- Update `.github/workflows/release.yml` so the `commitlint` job will create and push a baseline tag `v0.1.0` on `origin/main` when no reachable `v*` tag is found. 
- Add a `Validate release-please outputs` step after `googleapis/release-please-action@v4` to assert `release_created` is present (`true`/`false`) and that `tag_name` is a `vX.Y.Z` semantic tag when `release_created=true`.
- Preserve the workflow-level outputs `release_created` and `tag_name` for use by downstream jobs such as footer version injection.

### Testing
- The modified workflow YAML was parsed successfully with Ruby’s `YAML.load_file` to assert structural validity. (succeeded)
- A diff of ` .github/workflows/release.yml` was inspected to confirm the baseline-tag creation/push logic and the output validation step are present. (succeeded)
- A Python-based YAML check could not run because `PyYAML` is not installed in the environment, so that specific parser check was skipped. (skipped)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6b5bb7d8832f99b2fb4fcbcdc7a8)