### PR TITLE
Add moveCardToAnyTableau and unify auto-move for taps/double-clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1058,6 +1058,32 @@ function moveCardToAnyFoundation(type, idx, cardIdx){
   return false;
 }
 
+function moveCardToAnyTableau(type, idx, cardIdx){
+  if(type === 'pile'){
+    const srcPile = tableau[idx];
+    if(!srcPile.length) return false;
+    if(cardIdx < 0 || cardIdx >= srcPile.length) return false;
+    if(!srcPile[cardIdx].faceUp) return false;
+    for(let destI = 0; destI < 7; destI++){
+      if(destI === idx) continue;
+      if(executePileToPile(idx, cardIdx, destI)) return true;
+    }
+    return false;
+  }
+  if(type === 'hand'){
+    if(!hand[idx]) return false;
+    for(let destI = 0; destI < 7; destI++){
+      if(executeHandToPile(idx, destI)) return true;
+    }
+    return false;
+  }
+  return false;
+}
+
+function tryAutoMoveFromTap(type, idx, cardIdx){
+  return moveCardToAnyFoundation(type, idx, cardIdx) || moveCardToAnyTableau(type, idx, cardIdx);
+}
+
 function hasActiveRunToRecordAsLoss(){
   if(gameFinished) return false;
   if(moveCount > 0 || undoCount > 0 || elapsedMs > 0) return true;
@@ -1344,7 +1370,7 @@ function handleTouchEnd(e){
       lastTap.cardIdx === dragSource.cardIdx &&
       (now - lastTap.ts) <= DOUBLE_TAP_WINDOW_MS;
 
-    if(isDoubleTap && moveCardToAnyFoundation(dragSource.type, dragSource.idx, dragSource.cardIdx)){
+    if(isDoubleTap && tryAutoMoveFromTap(dragSource.type, dragSource.idx, dragSource.cardIdx)){
       selected = null;
       render();
       checkGameState();
@@ -1452,7 +1478,7 @@ function createCardEl(c, type, idx, cardIdx){
   el.ondblclick = (e) => {
     e.stopPropagation();
     if(!doubleClickToFoundationEnabled) return;
-    if(moveCardToAnyFoundation(type, idx, cardIdx)){
+    if(tryAutoMoveFromTap(type, idx, cardIdx)){
       selected = null;
       render();
       checkGameState();


### PR DESCRIPTION
### Motivation
- Provide a single, predictable helper to perform auto-tableau moves on tap/double-click so touch and mouse flows share the same logic and preserve multi-card moves.
- Ensure pile-origin moves only use face-up cards and preserve stacked-card behavior by routing through existing execution functions.

### Description
- Added `moveCardToAnyTableau(type, idx, cardIdx)` adjacent to `moveCardToAnyFoundation`, where `type==='pile'` verifies the index and `faceUp` state and attempts moves with `executePileToPile`, and `type==='hand'` iterates tableau targets using `executeHandToPile`.
- Implemented `tryAutoMoveFromTap(type, idx, cardIdx)` to attempt foundation moves first then tableau moves as a single source of truth for auto-moves.
- Replaced direct calls to the foundation-only helper in touch double-tap and card double-click handlers with `tryAutoMoveFromTap` so both touch and mouse use the unified behavior.

### Testing
- Ran `git diff --check` and there were no whitespace or diff-check issues.
- Started a local static server and attempted a Playwright-based page screenshot to validate UI behavior, but the headless browser crashed with a SIGSEGV in this environment so an in-browser validation artifact could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7ebce7f0832fa01b60679b22f2f4)