### PR TITLE
Remove redundant New button from header controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,7 +552,6 @@ header .controls > *{ flex: 0 0 auto; }
 <button id="autoBtn">Auto</button>
       <button id="giveUpBtn">Give Up</button>
       <button id="undoBtn">Undo</button>
-      <button id="newGameBtn">New</button>
     </div>
   </header>
 
@@ -1637,7 +1636,6 @@ function scheduleFit(){
     render();
   });
 }
-document.getElementById("newGameBtn").onclick = start;
 document.getElementById("undoBtn").onclick = undo;
 document.getElementById("autoBtn").onclick = autoPlay;
 document.getElementById("giveUpBtn").onclick = () => {
@@ -1720,7 +1718,7 @@ document.addEventListener('keydown', (event) => {
   menuToggleBtn?.focus();
 });
 
-['newGameBtn', 'autoBtn', 'giveUpBtn'].forEach((id) => {
+['autoBtn', 'giveUpBtn'].forEach((id) => {
   const actionBtn = document.getElementById(id);
   if(!actionBtn) return;
   actionBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- removed the `New` button (`#newGameBtn`) from the main header controls
- removed the now-unused `newGameBtn` click handler binding
- updated the mobile menu auto-close action list to exclude `newGameBtn`

## Rationale
The UI already has a **Give Up** flow and restart options in modal actions, so the top-level **New** button is redundant.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19b86abc4832fb3b08a36050b1bad)