### PR TITLE
Update suit style UI wording to High Contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@ width: 100%;
     body.suit-style-corners .suit-tr{ font-size: clamp(18px, calc(var(--card-w) * 0.32), 26px); }
     body.suit-style-corners .val-center{ opacity: 0.35; }
 
-    /* G) Colorblind-safe palette (also boosts glyph sizes a bit) */
+    /* G) High-contrast palette (also boosts glyph sizes a bit) */
     body.suit-style-cb .card.face{ color:#fff !important; border-color: rgba(255,255,255,.35); }
     body.suit-style-cb .card.face.suit-spades{ background: var(--s-spade-cb); }
     body.suit-style-cb .card.face.suit-hearts{ background: var(--s-heart-cb); }
@@ -536,7 +536,7 @@ header .controls > *{ flex: 0 0 auto; }
         <option value="watermark">Color + Watermark</option>
         <option value="pattern">Color + Pattern</option>
         <option value="corners">Big Corner Glyphs</option>
-        <option value="cb">Colorblind-Safe</option>
+        <option value="cb">High Contrast</option>
       </select>
 
       <label class="suit-style-label dblclick-foundation-label" for="doubleClickFoundationToggle">Double-click to Foundation</label>


### PR DESCRIPTION
### Motivation
- Improve the user-facing wording for the suit-style that aids color distinction by renaming labels to "High Contrast" while preserving existing storage keys and class behavior.

### Description
- Updated `index.html` to change the suit-style dropdown option label for `value="cb"` from `Colorblind-Safe` to `High Contrast` and updated the nearby CSS comment from `Colorblind-safe palette` to `High-contrast palette` without changing class names or storage keys.

### Testing
- Verified the changes by running `rg -n "Colorblind|colorblind|High Contrast|High-contrast" index.html`, inspected `git diff -- index.html`, checked `git status --short`, and captured a Playwright screenshot of `http://127.0.0.1:8000/index.html` to confirm the updated UI text, and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b5c39a74832f89f93833f1a0eee5)