### PR TITLE
Use CSS variables for card-back colors and add luminance cue

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,8 +138,23 @@ width: 100%;
     }
     .card:active { transform: scale(0.96); }
     .card.back {
-      background: repeating-linear-gradient(45deg, #1a237e, #1a237e 5px, #283593 5px, #283593 10px);
-      border: 1px solid #eee;
+      background:
+        repeating-linear-gradient(45deg, var(--card-back-a), var(--card-back-a) 5px, var(--card-back-b) 5px, var(--card-back-b) 10px);
+      border: 1px solid var(--card-back-border);
+      position: relative;
+      overflow: hidden;
+    }
+    .card.back::after {
+      content: "";
+      position: absolute;
+      inset: 8px;
+      border-radius: calc(var(--radius) - 1px);
+      border: 1px solid var(--card-back-accent);
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,0.06);
+      background:
+        radial-gradient(circle at center, var(--card-back-accent) 0 12%, transparent 13% 100%);
+      opacity: 0.8;
+      pointer-events: none;
     }
     
     .val-tl { 
@@ -304,6 +319,11 @@ width: 100%;
       --s-heart-cb: #B71C1C;
       --s-diamond-cb: #FFD54F;
       --s-club-cb: #00695C;
+
+      --card-back-a: #2f3346;
+      --card-back-b: #1f2434;
+      --card-back-border: #d8dae2;
+      --card-back-accent: rgba(245, 246, 255, 0.25);
     }
 
     body.suit-style-color .card.face.suit-spades{ background: var(--s-spade); }
@@ -393,6 +413,12 @@ width: 100%;
     body.suit-style-cb .card.face:not(.suit-diamonds) .suit-tr{ text-shadow: 0 1px 1px rgba(0,0,0,0.4); }
     body.suit-style-cb .card.face.suit-diamonds .val-tl,
     body.suit-style-cb .card.face.suit-diamonds .suit-tr{ text-shadow: 0 1px 0 rgba(255,255,255,0.35); }
+    body.suit-style-cb {
+      --card-back-a: #4b2d6b;
+      --card-back-b: #311b4a;
+      --card-back-border: #e8ddf7;
+      --card-back-accent: rgba(255,255,255,0.32);
+    }
 
   
 /* --- Responsive header + mobile menu --- */


### PR DESCRIPTION
### Motivation

- Make the card back styling themeable and easily overrideable so backs remain visually distinct from face suit palettes, including high-contrast modes.
- Preserve the existing stripe pattern while adding a non-hue luminance cue so distinction does not rely on color alone.

### Description

- Replace the fixed blue gradient on `.card.back` with a stripe background driven by `--card-back-a` and `--card-back-b` and use `--card-back-border` for the edge.
- Add a `.card.back::after` overlay that provides an inner border and a subtle radial center motif using `--card-back-accent` as an additional luminance cue while keeping the stripes.
- Define default card-back variables in `:root` with a slate/charcoal palette that does not reuse any face suit hue, and add `body.suit-style-cb` overrides with a deep purple palette to keep backs distinct from `--s-spade-cb`, `--s-heart-cb`, `--s-diamond-cb`, and `--s-club-cb`.
- Minor layout tweaks to support the overlay (`position: relative` / `overflow: hidden`) were applied; changes are contained in `index.html`.

### Testing

- Ran `rg` searches to confirm the new variables and selectors (`card-back-a`, `card.back::after`, `body.suit-style-cb`, and the suit cb variables`) were present and matched expected locations, and the search succeeded.
- Served the app locally with `python3 -m http.server 4173 --bind 0.0.0.0` and performed a Playwright run to capture a screenshot for visual verification, and the screenshot artifact was produced successfully.
- No automated unit tests were affected by this CSS-only change and all verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b9a7bbd4832fb5219fe7d538d6e7)