### PR TITLE
Adjust fit() width scaling to include top-row slot requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -850,6 +850,7 @@ function applyDealVariant(variantKey){
   const sel = document.getElementById("dealVariantSelect");
   if(sel && sel.value !== variantKey) sel.value = variantKey;
   try { localStorage.setItem(DEAL_VARIANT_KEY, variantKey); } catch(e) {}
+  scheduleFit();
 }
 
 function initDealVariantUI(){
@@ -1837,13 +1838,26 @@ function fit(){
   const baseH = baseW * 1.45;  // card height ratio
   const baseGap = 24;          // stack gap
   const baseColGap = 8;        // column gap
+  const topRowGap = 4;         // .foundations-row/.hand-row gap
+  const topSectionGap = 12;    // .top-section gap between zone groups
   const cardBorder = 2;        // rough border allowance
 
   const needW = (W, CG) => 7*(W + cardBorder) + 6*CG;
   const pileH = (N, H, G) => H + (N - 1) * G;
 
+  const currentConfig = getCurrentDealConfig();
+  const foundationSlots = 4;
+  const freeCellSlots = currentConfig.freeCells;
+
+  const foundationNeedW = foundationSlots * (baseW + cardBorder) + Math.max(0, foundationSlots - 1) * topRowGap;
+  const handNeedW = freeCellSlots > 0
+    ? freeCellSlots * (baseW + cardBorder) + Math.max(0, freeCellSlots - 1) * topRowGap
+    : 0;
+  const topSectionNeedW = foundationNeedW + handNeedW + (freeCellSlots > 0 ? topSectionGap : 0);
+
   // Compute a single scale factor that satisfies both width and height.
-  const targetNeedW = needW(baseW, baseColGap);
+  const tableauNeedW = needW(baseW, baseColGap);
+  const targetNeedW = Math.max(tableauNeedW, topSectionNeedW);
   const targetNeedH = pileH(maxLen, baseH, baseGap);
 
   // Avoid division by zero in pathological cases.


### PR DESCRIPTION
### Motivation
- Prevent horizontal overflow on narrow viewports (e.g. 360px) when the top row (foundations + free cells) is wider than the tableau, by making `fit()` account for both constraints.
- Re-run layout when a deal variant changes so the UI immediately recomputes sizes for a different `freeCells` count.

### Description
- Call `scheduleFit()` from `applyDealVariant()` so variant changes re-run the layout pass immediately (`applyDealVariant()` now triggers `scheduleFit()`).
- Add `topRowGap` and `topSectionGap` constants and compute `foundationNeedW` (always 4 slots) and `handNeedW` (`getCurrentDealConfig().freeCells`) to model the top-row width using card width, per-row gap (`4px`) and inter-zone gap (`12px` only when both groups are visible).
- Compute `tableauNeedW` (existing 7-pile model) and set `targetNeedW = Math.max(tableauNeedW, topSectionNeedW)` so the horizontal scale factor `sW` uses the wider of the two constraints.
- Leave visual overflow CSS hardening out of the primary fix (no `overflow-x: hidden` change); sizing logic is the source-of-truth fix.

### Testing
- Started a static server with `python3 -m http.server 4173` to exercise the page under a narrow viewport, and the server startup succeeded.
- Ran automated browser verification attempts via Playwright (Chromium/Firefox/WebKit) to capture a screenshot after applying `applyDealVariant('cells4')` and `start()`, but all Playwright attempts failed in this environment due to browser launch/connection errors, so no screenshot artifact was produced and visual confirmation could not be completed.
- No unit tests exist for layout logic; code changes were applied and the repository updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a210c7f238832f8955ba95cc9a4650)