### PR TITLE
fix: bump website version to v0.2.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -762,7 +762,7 @@ const STATS_HISTORY_KEY = "rs_statsHistory_v1";
 const DBL_CLICK_FOUNDATION_KEY = "rs_dblClickFoundation_v1";
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const MAX_STATS_HISTORY = 100;
-const APP_VERSION = "v0.2.0";
+const APP_VERSION = "v0.2.1";
 
 const DEAL_VARIANTS = {
   cells0: {


### PR DESCRIPTION
### Motivation
- Bump the displayed app version to `v0.2.1` to reflect the new release and ensure the change is categorized as a `fix` for Commitlint.

### Description
- Update the `APP_VERSION` constant in `index.html` from `v0.2.0` to `v0.2.1` so the footer displays the new version.

### Testing
- Verified the change with `rg -n "0\.2\.0|version|v0\.2" .`, served the site with `python3 -m http.server 4173`, and captured a Playwright screenshot saved to `artifacts/version-v0.2.1.png`, all succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a212e1176c832fbc4da7047975394d)