### PR TITLE
Remove header New Game button and initialization handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -660,7 +660,6 @@ header .controls > *{ flex: 0 0 auto; }
         <option value="cells4">4</option>
       </select>
 
-      <button id="newGameBtn">New Game</button>
 
       
       <button id="rulesBtn" title="View rules">Rules</button>
@@ -1897,7 +1896,6 @@ function scheduleFit(){
 }
 document.getElementById("undoBtn").onclick = undo;
 document.getElementById("autoBtn").onclick = autoPlay;
-document.getElementById("newGameBtn").onclick = start;
 document.getElementById("giveUpBtn").onclick = () => {
   if(hasActiveRunToRecordAsLoss() && !runResultRecorded) recordGameResult('loss');
   document.getElementById('modalLose').classList.add('active');


### PR DESCRIPTION
### Motivation
- Remove a redundant header-level `New Game` control to declutter the header and avoid a duplicate entry point for starting a run.

### Description
- Deleted the `<button id="newGameBtn">New Game</button>` element and removed the initialization binding `document.getElementById("newGameBtn").onclick = start;` from `index.html`, while leaving `initDealVariantUI()`'s `change` listener (which calls `applyDealVariant(sel.value); start();`) and the modal `start()` buttons intact.

### Testing
- Used `rg` to verify the removal and presence of `dealVariantSelect` and modal `onclick="start()"`, served the page with `python3 -m http.server 4173`, and captured a Playwright screenshot of the header to confirm the button is gone; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a216b3a47c832f87cd3a7d5d0f4563)