### PR TITLE
chore: bump app version to v0.2.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,7 +765,7 @@ const STATS_HISTORY_KEY = "rs_statsHistory_v1";
 const DBL_CLICK_FOUNDATION_KEY = "rs_dblClickFoundation_v1";
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const MAX_STATS_HISTORY = 100;
-const APP_VERSION = "v0.2.1";
+const APP_VERSION = "v0.2.3";
 
 const DEAL_VARIANTS = {
   cells0: {


### PR DESCRIPTION
### Motivation
- Bump the in-app version so the UI footer and runtime metadata reflect the new release `v0.2.3`.

### Description
- Updated `const APP_VERSION` in `index.html` from `v0.2.1` to `v0.2.3`.

### Testing
- Verified the change with `rg -n "APP_VERSION|v0.2.3" index.html`, which succeeded.
- Served the site with `python -m http.server 8000` and confirmed the page loaded successfully.
- Captured a Playwright screenshot of `http://127.0.0.1:8000/index.html` saved to `artifacts/version-v0.2.3.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21981e5e4832fbc5d735a47098bb0)