### PR TITLE
Debounce single-click and cancel on double-click to prevent duplicate card actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1737,6 +1737,7 @@ function cardClick(type, idx, cardIdx){
 
 function createCardEl(c, type, idx, cardIdx){
   const el = document.createElement("div");
+  let clickTimeoutId = null;
   el.className = "card";
   if(!c.faceUp){ el.classList.add("back"); return el; }
   el.classList.add("face");
@@ -1753,16 +1754,25 @@ function createCardEl(c, type, idx, cardIdx){
   el.ontouchstart = (e) => handleTouchStart(e, type, idx, cardIdx);
   el.ontouchmove = handleTouchMove;
   el.ontouchend = handleTouchEnd;
-  el.onclick = (e) => { e.stopPropagation(); cardClick(type, idx, cardIdx); };
+  el.onclick = (e) => {
+    e.stopPropagation();
+    if(clickTimeoutId !== null) return;
+    clickTimeoutId = setTimeout(() => {
+      clickTimeoutId = null;
+      cardClick(type, idx, cardIdx);
+    }, 250);
+  };
   el.ondblclick = (e) => {
     e.stopPropagation();
+    if(clickTimeoutId !== null){
+      clearTimeout(clickTimeoutId);
+      clickTimeoutId = null;
+    }
     if(!doubleClickToFoundationEnabled) return;
     if(tryAutoMoveFromTap(type, idx, cardIdx)){
       selected = null;
       render();
       checkGameState();
-    } else {
-      cardClick(type, idx, cardIdx);
     }
   };
   el.innerHTML = `<div class="val-tl">${c.rank}</div><div class="suit-tr">${c.suit}</div><div class="val-center">${c.rank}</div>`;


### PR DESCRIPTION
### Motivation
- Prevent a double-click gesture from triggering both single-click and double-click logic and producing duplicate toggles/moves on cards.
- Ensure `tryAutoMoveFromTap` remains the first double-click action when `doubleClickToFoundationEnabled` is true. 
- Only reset selection and update UI/state when an auto-move actually succeeds to avoid spurious state changes. 

### Description
- Added a local `clickTimeoutId` in `createCardEl` and replaced the immediate `cardClick(...)` in `el.onclick` with a delayed handler that fires after `250ms` to debounce single clicks. 
- Updated `el.ondblclick` to clear any pending single-click timeout before performing double-click logic. 
- Preserved `tryAutoMoveFromTap(type, idx, cardIdx)` as the first action on double-click and removed the fallback `cardClick(...)` call from the double-click path to avoid duplicate execution. 
- Kept the explicit `selected = null` + `render()` + `checkGameState()` sequence only in the successful auto-move branch so selection is only reset when an auto-move occurs. 

### Testing
- Applied the patch successfully to `index.html` and verified the file was updated without errors. 
- Ran a code search to confirm presence of `clickTimeoutId`, the new delayed `onclick` handler, and the updated `ondblclick` behavior using pattern searches; results matched the intended changes. 
- Inspected the modified region (`createCardEl`) to confirm the timeout-based single-click, timeout cancellation on double-click, preserved `tryAutoMoveFromTap` ordering, and removal of the fallback `cardClick` path; no automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a23a9e75f8832fa2f032e469344daf)