### PR TITLE
Remove dead code in moveCardToAnyTableau

### DIFF
--- a/index.html
+++ b/index.html
@@ -1338,25 +1338,6 @@ function moveCardToAnyTableau(type, idx, cardIdx){
   if(targetIdx === -1) return false;
   if(type === 'pile') return executePileToPile(idx, cardIdx, targetIdx);
   return executeHandToPile(idx, targetIdx);
-  if(type === 'pile'){
-    const srcPile = tableau[idx];
-    if(!srcPile.length) return false;
-    if(cardIdx < 0 || cardIdx >= srcPile.length) return false;
-    if(!srcPile[cardIdx].faceUp) return false;
-    for(let destI = 0; destI < 7; destI++){
-      if(destI === idx) continue;
-      if(executePileToPile(idx, cardIdx, destI)) return true;
-    }
-    return false;
-  }
-  if(type === 'hand'){
-    if(!hand[idx]) return false;
-    for(let destI = 0; destI < 7; destI++){
-      if(executeHandToPile(idx, destI)) return true;
-    }
-    return false;
-  }
-  return false;
 }
 
 function tryAutoMoveFromTap(type, idx, cardIdx){


### PR DESCRIPTION
## Summary
- removed unreachable fallback logic after the hard return in `moveCardToAnyTableau`
- kept the deterministic target-selection path unchanged

## Details
In `index.html`, `moveCardToAnyTableau` returned immediately via:
- `return executePileToPile(idx, cardIdx, targetIdx);` or
- `return executeHandToPile(idx, targetIdx);`

The subsequent block that iterated all tableau destinations could never execute. This PR deletes that dead block to simplify control flow and avoid misleading future maintenance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2dad210a8832f960c4b2d8fb010c7)