### PR TITLE
Standardize rules modal stacking order

### DIFF
--- a/index.html
+++ b/index.html
@@ -588,7 +588,7 @@ header .controls > *{ flex: 0 0 auto; }
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 10000;
 }
 .rules-modal.hidden{ display: none; }
 .rules-content{


### PR DESCRIPTION
## Summary
- Updated `.rules-modal` in `index.html` to use `z-index: 10000` instead of `1000`
- Aligns the rules modal stacking context with `.modal-overlay` so it is not obscured when multiple overlays are active

## Testing
- Static CSS change only; no runtime tests executed

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2db186bf0832f86a6ea86e8cdbe68)