### PR TITLE
Optimize touch drag ghost creation for mobile performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1610,7 +1610,7 @@ function handleTouchMove(e){
     const original = touchOriginalEl || e.target.closest('.card');
     if(original){
         const rect = original.getBoundingClientRect();
-        touchClone.innerHTML = original.innerHTML;
+        touchClone.replaceChildren(original.cloneNode(true));
         touchClone.className = "card";
         touchClone.style.width = rect.width + "px";
         touchClone.style.height = rect.height + "px";


### PR DESCRIPTION
## Summary
- replaced `touchClone.innerHTML = original.innerHTML` in touch drag ghost creation
- now uses `touchClone.replaceChildren(original.cloneNode(true))` to avoid HTML string parsing during touch move drag initiation

## Why
- cloning DOM nodes directly is typically lighter on lower-end mobile devices than rebuilding via `innerHTML`
- keeps existing drag ghost behavior and styling intact while reducing work during touch interactions

## Files changed
- `index.html`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2db3415e0832f9ad19e0c7e7f92ef)