### PR TITLE
fix(ui): resolve broken Rules modal initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -2046,23 +2046,21 @@ window.addEventListener('blur', syncTimerPresence);
 document.addEventListener('visibilitychange', syncTimerPresence);
 
 // Rules modal behavior
-document.addEventListener('DOMContentLoaded', () => {
-  const rulesBtn = document.getElementById('rulesBtn');
-  const modal = document.getElementById('rulesModal');
-  const closeBtn = document.getElementById('closeRulesBtn');
+const rulesBtn = document.getElementById('rulesBtn');
+const modal = document.getElementById('rulesModal');
+const closeBtn = document.getElementById('closeRulesBtn');
 
-  if(rulesBtn && modal){
-    rulesBtn.addEventListener('click', () => modal.classList.remove('hidden'));
-  }
-  if(closeBtn && modal){
-    closeBtn.addEventListener('click', () => modal.classList.add('hidden'));
-  }
-  if(modal){
-    modal.addEventListener('click', (e) => {
-      if(e.target === modal) modal.classList.add('hidden');
-    });
-  }
-});
+if(rulesBtn && modal){
+  rulesBtn.addEventListener('click', () => modal.classList.remove('hidden'));
+}
+if(closeBtn && modal){
+  closeBtn.addEventListener('click', () => modal.classList.add('hidden'));
+}
+if(modal){
+  modal.addEventListener('click', (e) => {
+    if(e.target === modal) modal.classList.add('hidden');
+  });
+}
 
 </script>
 


### PR DESCRIPTION
### Motivation
- The `DOMContentLoaded` wrapper registered modal handlers too late because the script lives at the bottom of `<body>`, so the `Rules` button was non-functional when the event had already fired.

### Description
- Removed the `document.addEventListener('DOMContentLoaded', ...)` wrapper and initialized `#rulesBtn`, `#rulesModal`, and `#closeRulesBtn` handlers immediately at script execution time while keeping open/close and backdrop-click behavior intact.

### Testing
- Started a local `python3 -m http.server` and ran a Playwright script that loaded `index.html`, clicked `#rulesBtn`, and captured a screenshot confirming the modal opens as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e19757a4832f9f3dd5d7e75c470d)