### PR TITLE
fix: restore two-pass king-to-empty tableau gating

### DIFF
--- a/index.html
+++ b/index.html
@@ -1511,7 +1511,7 @@ function findAnyMove(highlight){
           if(i===t) continue;
           const tp = tableau[t];
           if(!tp.length){
-            const movingKingToEmpty = c.rank === 'K' && j > 0 && (allowBaseKingToEmpty || j > 0);
+            const movingKingToEmpty = c.rank === 'K' && j > 0 && allowBaseKingToEmpty;
             if(movingKingToEmpty){
               if(highlight) { highlightPileCard(i,j,'source'); highlightPile(t,'target'); }
               return true;


### PR DESCRIPTION
### Motivation
- Restore intended two-pass move search so `allowBaseKingToEmpty` actually controls whether a base-king move to an empty tableau is considered in `findPileToTableauMove`.

### Description
- Replace the always-true expression in `index.html` so `movingKingToEmpty` is computed as `c.rank === 'K' && j > 0 && allowBaseKingToEmpty`, making the two passes in `findAnyMove` behave differently as designed.

### Testing
- No automated tests were run; the change is a single-line logical fix and was validated by inspecting the resulting code diff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e1cd2690832fa50a7116c904309d)