### PR TITLE
fix(game): guard hand-slot lookup in highlight helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -1572,7 +1572,10 @@ function closeModals(){
 /* --- HIGHLIGHTERS --- */
 function highlightHand(idx, type){ 
   const el = document.querySelector(`.hand-slot[data-id="${idx}"] .card`); if(el) el.classList.add('hint-'+type); 
-  else if(type==='target') document.querySelector(`.hand-slot[data-id="${idx}"]`).classList.add('hint-'+type);
+  else if(type==='target') {
+    const slotEl = document.querySelector(`.hand-slot[data-id="${idx}"]`);
+    if(slotEl) slotEl.classList.add('hint-'+type);
+  }
 }
 function highlightFoundation(idx, type){ 
   const el = document.querySelector(`.foundation[data-id="${idx}"]`); if(el) el.classList.add('hint-'+type); 


### PR DESCRIPTION
### Motivation
- Prevent an uncaught `TypeError` when a `.hand-slot[data-id="${idx}"]` element is missing by ensuring we only call `classList.add` on an actual element, matching the safety of other highlight helpers.

### Description
- Add a null guard in `highlightHand` so that when `type === 'target'` the code does `const slotEl = document.querySelector(...)` and only calls `slotEl.classList.add('hint-'+type)` if `slotEl` exists, while preserving the existing card-level highlighting behavior.

### Testing
- Ran `rg -n "highlightHand|hand-slot\[data-id" -S` to locate usages and confirm the change applies to the intended code paths and it succeeded.
- Inspected the patch with `git diff -- index.html` to verify the guarded lookup was added and it showed the expected diff.
- Performed a network probe with `curl -I https://example.com` which returned `403 Forbidden` in this environment and is unrelated to the code fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e2203820832fa7f52b582e112e0a)