### PR TITLE
feat(ui): emphasize hinted source card and add a11y announcement

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,13 +209,46 @@
     .drag-over { background: rgba(255, 218, 43, 0.4); border-color: #ffda2b; box-shadow: 0 0 8px #ffda2b; }
     .selected { outline: 3px solid #ffda2b; z-index: 100 !important; }
 
-    @keyframes pulse-pink {
-      0% { box-shadow: 0 0 0 0 rgba(236, 64, 122, 0.7); border-color: #ec407a; }
-      70% { box-shadow: 0 0 0 10px rgba(236, 64, 122, 0); border-color: #ec407a; }
-      100% { box-shadow: 0 0 0 0 rgba(236, 64, 122, 0); border-color: #ec407a; }
+    @keyframes hint-pulse {
+      0% {
+        box-shadow: 0 0 0 0 rgba(211, 47, 47, 0.95), 0 0 0 2px rgba(255, 235, 59, 0.95);
+        border-color: #d32f2f;
+      }
+      70% {
+        box-shadow: 0 0 0 12px rgba(211, 47, 47, 0), 0 0 0 2px rgba(255, 235, 59, 0.95);
+        border-color: #d32f2f;
+      }
+      100% {
+        box-shadow: 0 0 0 0 rgba(211, 47, 47, 0), 0 0 0 2px rgba(255, 235, 59, 0.95);
+        border-color: #d32f2f;
+      }
     }
-    .hint-source { animation: pulse-pink 1.5s infinite; z-index: 1000 !important; }
+    .hint-source {
+      border: 3px solid #d32f2f !important;
+      outline: 3px dashed #ffeb3b;
+      outline-offset: 2px;
+      animation: hint-pulse 1.1s infinite;
+      z-index: 1000 !important;
+    }
     .hint-target { border: 2px solid #ec407a; background: rgba(236, 64, 122, 0.2); }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .hint-source {
+        animation: none;
+      }
+    }
 
     #drag-ghost {
       position: fixed; pointer-events: none; z-index: 9999;
@@ -636,6 +669,7 @@ header .controls > *{ flex: 0 0 auto; }
     </div>
     <div class="controls" id="headerControls">
       <button id="hintBtn" onclick="showHint()">Hint</button>
+      <span id="hintAnnouncement" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></span>
       
       <label class="suit-style-label" for="suitStyleSelect">Suit Style:</label>
       <select id="suitStyleSelect" title="Choose suit distinction style">
@@ -1555,41 +1589,60 @@ function enumerateMoves({ includeCellShuffles=true, suppressImmediateReverse=nul
   return moves;
 }
 
+
+function announceHint(message){
+  const announcer = document.getElementById('hintAnnouncement');
+  if(!announcer) return;
+  announcer.textContent = '';
+  setTimeout(() => { announcer.textContent = message; }, 20);
+}
+
+function describeCard(card){
+  if(!card) return 'card';
+  const suitMap = { '♠': 'spades', '♥': 'hearts', '♦': 'diamonds', '♣': 'clubs' };
+  const rankMap = { A: 'ace', J: 'jack', Q: 'queen', K: 'king' };
+  const rank = rankMap[card.rank] || card.rank;
+  const suit = suitMap[card.suit] || card.suit;
+  return `${rank} of ${suit}`;
+}
+
+function announceMoveHint(move){
+  if(move.type === 'hand_to_foundation' || move.type === 'hand_to_tableau'){
+    const card = hand[move.source.handIdx];
+    announceHint(`Hint: move ${describeCard(card)} from free cell ${move.source.handIdx + 1}.`);
+    return;
+  }
+
+  if(move.type === 'pile_to_foundation' || move.type === 'pile_to_tableau' || move.type === 'pile_to_hand'){
+    const pile = tableau[move.source.pileIdx];
+    const card = pile && pile[move.source.cardIdx];
+    announceHint(`Hint: move ${describeCard(card)} from tableau column ${move.source.pileIdx + 1}.`);
+    return;
+  }
+
+  announceHint('Hint available: move the highlighted card.');
+}
+
 function findAnyMove(highlight){
   const moves = enumerateMoves({ includeCellShuffles: true });
   const move = moves[0];
   if(!move) return false;
   if(!highlight) return true;
 
-  if(move.type === 'hand_to_foundation'){
+  if(move.type === 'hand_to_foundation' || move.type === 'hand_to_tableau'){
     highlightHand(move.source.handIdx, 'source');
-    highlightFoundation(move.target.foundationIdx, 'target');
-    return true;
-  }
-  if(move.type === 'pile_to_foundation'){
-    highlightPileCard(move.source.pileIdx, move.source.cardIdx, 'source');
-    highlightFoundation(move.target.foundationIdx, 'target');
-    return true;
-  }
-  if(move.type === 'hand_to_tableau'){
-    highlightHand(move.source.handIdx, 'source');
-    if(move.target.targetCardIdx === null) highlightPile(move.target.pileIdx, 'target');
-    else highlightPileCard(move.target.pileIdx, move.target.targetCardIdx, 'target');
-    return true;
-  }
-  if(move.type === 'pile_to_tableau'){
-    highlightPileCard(move.source.pileIdx, move.source.cardIdx, 'source');
-    if(move.target.targetCardIdx === null) highlightPile(move.target.pileIdx, 'target');
-    else highlightPileCard(move.target.pileIdx, move.target.targetCardIdx, 'target');
-    return true;
-  }
-  if(move.type === 'pile_to_hand'){
-    highlightPileCard(move.source.pileIdx, move.source.cardIdx, 'source');
-    highlightHand(move.target.handIdx, 'target');
+    announceMoveHint(move);
     return true;
   }
 
-  return false;
+  if(move.type === 'pile_to_foundation' || move.type === 'pile_to_tableau' || move.type === 'pile_to_hand'){
+    highlightPileCard(move.source.pileIdx, move.source.cardIdx, 'source');
+    announceMoveHint(move);
+    return true;
+  }
+
+  announceMoveHint(move);
+  return true;
 }
 
 function isWin(){


### PR DESCRIPTION
## Summary
- updated hint visuals to strongly emphasize the suggested source card with a high-contrast border, dashed outline, and pulse effect
- changed hint behavior so only the source card is highlighted (target location is no longer highlighted)
- added an accessible live-region announcement that describes the suggested card and where it is (free cell/tableau column)
- added reduced-motion handling for hint animation

## Testing
- static review only (no automated test suite run)
- attempted to generate a screenshot via Playwright, but browser launch failed in this environment (SIGSEGV)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2fc02b7ac832faa82353bd85a797b)