### PR TITLE
fix(touch): guard click path after touch end

### DIFF
--- a/index.html
+++ b/index.html
@@ -1688,6 +1688,8 @@ function highlightPileCard(pileIdx, cardIdx, type){
 
 /* --- INTERACTION --- */
 let dragSource = null;
+let lastTouchEndTs = 0;
+const TOUCH_CLICK_GUARD_MS = 400;
 let touchClone = document.getElementById('drag-ghost');
 let touchStartCoords = {x:0, y:0};
 let isDragGesture = false;
@@ -1719,6 +1721,7 @@ function handleDrop(e, targetType, targetIdx){
 function handleTouchStart(e, type, idx, cardIdx){
   clearHints();
   if(type === 'pile' && !tableau[idx][cardIdx].faceUp) return;
+  e.preventDefault();
   const touch = e.touches[0];
   touchStartCoords = {x: touch.clientX, y: touch.clientY};
   isDragGesture = false;
@@ -1765,6 +1768,7 @@ function handleTouchEnd(e){
       let tIdx = parseInt(target.dataset.id);
       commitMove(tType, tIdx);
     } else render();
+    lastTouchEndTs = Date.now();
   } else {
     e.preventDefault();
     if(tryAutoMoveFromTap(dragSource.type, dragSource.idx, dragSource.cardIdx)){
@@ -1774,6 +1778,7 @@ function handleTouchEnd(e){
     } else {
       cardClick(dragSource.type, dragSource.idx, dragSource.cardIdx);
     }
+    lastTouchEndTs = Date.now();
   }
   dragSource = null;
   isDragGesture = false;
@@ -1870,6 +1875,7 @@ function createCardEl(c, type, idx, cardIdx){
   el.ontouchmove = handleTouchMove;
   el.ontouchend = handleTouchEnd;
   el.onclick = (e) => {
+    if(Date.now() - lastTouchEndTs < TOUCH_CLICK_GUARD_MS) return;
     e.stopPropagation();
     if(tryAutoMoveFromTap(type, idx, cardIdx)){
       selected = null;


### PR DESCRIPTION
### Motivation
- Prevent a synthetic click generated after a touch gesture from also executing the click-path, ensuring each user gesture only triggers one code path.

### Description
- Add a module-scoped timestamp guard `lastTouchEndTs` and a `TOUCH_CLICK_GUARD_MS` threshold (400ms) to block immediate follow-up clicks.
- Call `e.preventDefault()` in `handleTouchStart` to reduce synthetic click generation on touch-start.
- Set `lastTouchEndTs = Date.now()` at the end of both drag-drop and tap branches in `handleTouchEnd` so the guard is applied after touch processing.
- Short-circuit the card `onclick` handler in `createCardEl` when the click occurs within the guard window to avoid duplicate `tryAutoMoveFromTap`/`cardClick` execution.

### Testing
- Started a local server with `python3 -m http.server 4173 --directory /workspace/rezanow-site` and served the app (succeeded).
- Ran a Playwright mobile-touch smoke test that exercised a tap and reported `tap_delta: 1`, indicating the tap-to-automove ran once (succeeded).
- Ran an instrumented Playwright check that confirmed the guarded click path prevented `tryAutoMoveFromTap` immediately after a touch while an unguarded click still triggers it (succeeded).
- Captured a browser screenshot artifact at `artifacts/touch-guard-check.png` during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a305cf2310832f8987a35c47735d6c)