### PR TITLE
fix(ui): restore modal state after loading finished game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1456,6 +1456,16 @@ function canFinalizeLoss(){
   return historyStack.length === 0;
 }
 
+function restorePostLoadModalState(){
+  if(!gameFinished) return;
+
+  if(isWin()){
+    document.getElementById('modalWin').classList.add('active');
+  } else {
+    document.getElementById('modalLose').classList.add('active');
+  }
+}
+
 /* --- GAME STATE CHECKS --- */
 function checkGameState(){
   if(isWin()){
@@ -2048,6 +2058,7 @@ if(loadPersistedGameState()){
   startTimer();
   fit();
   render();
+  restorePostLoadModalState();
 } else {
   start();
 }


### PR DESCRIPTION
### Motivation
- Reconstruct the win/lose modal UI when a persisted finished game is loaded so the app visually reflects completed state without re-recording results.

### Description
- Add `restorePostLoadModalState()` near `checkGameState()` that, when `gameFinished` is true, activates `modalWin` if `isWin()` else `modalLose`, and call it in the `if(loadPersistedGameState())` startup branch immediately after `render()` while leaving `recordGameResult()` calls unchanged.

### Testing
- Verified anchors and diff with `rg` and `git diff`, served the app via `python3 -m http.server` and ran a Playwright script that simulates a finished game and invokes `restorePostLoadModalState()` to capture a screenshot, and the automated checks and screenshot run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30a435134832fb19e5416fd7421e8)