### PR TITLE
feat(hints): score and sort hint candidate moves

### DIFF
--- a/index.html
+++ b/index.html
@@ -1606,6 +1606,79 @@ function enumerateMoves({ includeCellShuffles=true, includeAllCellMoves=false, s
   return moves;
 }
 
+function scoreMove(move, gameState){
+  const state = gameState || { tableau, hand, foundations };
+  const sourcePile = move.source && Number.isInteger(move.source.pileIdx)
+    ? state.tableau[move.source.pileIdx]
+    : null;
+
+  const revealsFaceDown = !!(
+    sourcePile &&
+    Number.isInteger(move.source.cardIdx) &&
+    move.source.cardIdx > 0 &&
+    sourcePile[move.source.cardIdx - 1] &&
+    !sourcePile[move.source.cardIdx - 1].faceUp
+  );
+
+  const createsTableauSequence = move.type === 'pile_to_tableau' &&
+    sourcePile &&
+    Number.isInteger(move.source.cardIdx) &&
+    sourcePile.length - move.source.cardIdx > 1;
+
+  const extendsTableauOnCard =
+    (move.type === 'pile_to_tableau' || move.type === 'hand_to_tableau') &&
+    Number.isInteger(move.target.targetCardIdx);
+
+  const unlocksNearTermProgress = () => {
+    if(move.type !== 'pile_to_hand' || !sourcePile || !Number.isInteger(move.target.handIdx)) return false;
+
+    const simulatedState = {
+      tableau: state.tableau.map(p => p.map(card => ({ ...card }))),
+      hand: [...state.hand],
+      foundations: state.foundations.map(p => p.map(card => ({ ...card })))
+    };
+
+    const fromPile = simulatedState.tableau[move.source.pileIdx];
+    const movedCard = fromPile.pop();
+    if(!movedCard) return false;
+    simulatedState.hand[move.target.handIdx] = movedCard;
+    if(fromPile.length && !fromPile[fromPile.length - 1].faceUp){
+      fromPile[fromPile.length - 1].faceUp = true;
+    }
+
+    const resultingMoves = enumerateMoves({
+      includeCellShuffles: false,
+      suppressImmediateReverse: { handIdx: move.target.handIdx, pileIdx: move.source.pileIdx },
+      state: simulatedState
+    });
+
+    return resultingMoves.some(nextMove =>
+      nextMove.type === 'hand_to_foundation' ||
+      nextMove.type === 'pile_to_foundation' ||
+      nextMove.type === 'hand_to_tableau' ||
+      nextMove.type === 'pile_to_tableau'
+    );
+  };
+
+  let score = 0;
+
+  if(move.type === 'hand_to_foundation' || move.type === 'pile_to_foundation') score += 100;
+  if(move.type === 'pile_to_tableau' || move.type === 'hand_to_tableau') score += 35;
+  if(revealsFaceDown) score += 45;
+  if(createsTableauSequence) score += 15;
+  if(extendsTableauOnCard) score += 10;
+
+  if(move.type === 'pile_to_hand'){
+    const hasNearTermProgress = unlocksNearTermProgress();
+    score += 3;
+    if(revealsFaceDown) score += 35;
+    if(hasNearTermProgress) score += 25;
+    if(!revealsFaceDown && !hasNearTermProgress) score -= 15;
+  }
+
+  return score;
+}
+
 
 function announceHint(message){
   const announcer = document.getElementById('hintAnnouncement');
@@ -1641,8 +1714,12 @@ function announceMoveHint(move){
 }
 
 function findAnyMove(highlight, { includeAllCellMoves=false } = {}){
+  const gameState = { tableau, hand, foundations };
   const moves = enumerateMoves({ includeCellShuffles: true, includeAllCellMoves });
-  const move = moves[0];
+  const move = moves
+    .map(candidate => ({ candidate, score: scoreMove(candidate, gameState) }))
+    .sort((a, b) => b.score - a.score)
+    .map(({ candidate }) => candidate)[0];
   if(!move) return false;
   if(!highlight) return true;
 


### PR DESCRIPTION
### Motivation
- Improve hint quality by preferring moves that advance the game state such as moving to foundations, revealing facedown cards, and building useful tableau sequences.
- De-prioritize neutral housekeeping moves (e.g. moving tableau top to a free cell) unless they reveal or unlock near-term progress.
- Preserve accurate loss detection by keeping exhaustive legal checks for “out of moves.”

### Description
- Added a new `scoreMove(move, gameState)` helper in `index.html` that assigns higher scores to `*_to_foundation`, moves that reveal a facedown card, and moves that create/extend useful tableau sequences, and lowers score for neutral `pile_to_hand` moves unless they unlock progress via a simulated state.
- Updated `findAnyMove(highlight, { includeAllCellMoves=false })` to compute scores for all candidates and sort them by descending score before selecting a hint.
- Kept `checkGameState()` loss logic unchanged so it still calls `findAnyMove(false, { includeAllCellMoves: true })` to ensure exhaustive move detection.

### Testing
- Located and inspected the edited regions with `rg` to confirm `scoreMove` and updated `findAnyMove` are present and referenced correctly, and these checks succeeded.
- Printed and reviewed the modified `index.html` sections with `sed`/`nl` to validate placement and integration of the helper, and this verification succeeded.
- Ran a lightweight Python edit verification script to ensure the intended code block shape was applied, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4943200b4832fa7dd72a7147caaa9)