### PR TITLE
chore: bump patch version to v0.2.11

### DIFF
--- a/index.html
+++ b/index.html
@@ -843,7 +843,7 @@ const GAME_STATE_KEY = "rs_gameState_v1";
 const STATS_HISTORY_KEY = "rs_statsHistory_v1";
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const MAX_STATS_HISTORY = 100;
-const APP_VERSION = "v0.2.10";
+const APP_VERSION = "v0.2.11";
 
 const DEAL_VARIANTS = {
   cells0: {


### PR DESCRIPTION
### Motivation
- Bump the in-app patch version so the UI and build metadata reflect the new micro-release.

### Description
- Update the `APP_VERSION` constant in `index.html` from `v0.2.10` to `v0.2.11` and commit the change.

### Testing
- Ran `git diff -- index.html` and committed with `git commit -m "chore: bump patch version to v0.2.11"`, both succeeded; attempted to start `python3 -m http.server 4173` and capture a Playwright screenshot but the local server was inaccessible and the screenshot step failed with `ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a496f0fe48832f81b833ea53acfb2f)