### PR TITLE
fix(game): resolve duplicate move declaration in hint search

### DIFF
--- a/index.html
+++ b/index.html
@@ -1843,11 +1843,11 @@ function runHintRegressionScenario(){
 function findAnyMove(highlight, { includeAllCellMoves=false } = {}){
   const gameState = { tableau, hand, foundations };
   const moves = enumerateMoves({ includeCellShuffles: true, includeAllCellMoves });
-  const move = moves
+  const rankedMove = moves
     .map(candidate => ({ candidate, score: scoreMove(candidate, gameState) }))
     .sort((a, b) => b.score - a.score)
     .map(({ candidate }) => candidate)[0];
-  if(!move) return false;
+  if(!rankedMove) return false;
   if(!highlight) return true;
 
   const move = selectHintMove(moves);


### PR DESCRIPTION
### Motivation
- Fix a `SyntaxError` in `findAnyMove` caused by declaring `const move` twice that prevented the game's hint/script logic from running.

### Description
- Rename the initially computed best-move variable to `rankedMove` and update the existence check to `if(!rankedMove) return false;` while preserving `selectHintMove(moves)` for the highlight flow.

### Testing
- Verified the edit with `git diff -- index.html` and inspected the function via `node -e "const fs=require('fs'); const html=fs.readFileSync('index.html','utf8'); const start=html.indexOf('function findAnyMove'); console.log(html.slice(start,start+420));"`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a499d5ddb4832f8ec3dd9012f8aebe)