### PR TITLE
fix(hints): prioritize king moves to empty tableau

### DIFF
--- a/index.html
+++ b/index.html
@@ -1796,14 +1796,68 @@ function scoreHintMove(move){
   return score;
 }
 
+function scoreEmptyTableauKingHeuristic(move, gameState = { tableau, hand, foundations }){
+  const isKingToEmptyTableau =
+    (move.type === 'hand_to_tableau' || move.type === 'pile_to_tableau') &&
+    move.target &&
+    move.target.targetCardIdx === null;
+
+  if(!isKingToEmptyTableau) return 0;
+
+  if(move.type !== 'pile_to_tableau') return 0;
+
+  const sourcePile = gameState.tableau[move.source.pileIdx] || [];
+  if(!sourcePile.length || !Number.isInteger(move.source.cardIdx)) return 0;
+
+  const movingLength = sourcePile.length - move.source.cardIdx;
+  const exposedCard = move.source.cardIdx > 0 ? sourcePile[move.source.cardIdx - 1] : null;
+  const revealsFaceDown = !!(exposedCard && !exposedCard.faceUp);
+
+  const simulatedTableau = gameState.tableau.map(pile => pile.map(card => ({ ...card })));
+  const sourceAfterMove = simulatedTableau[move.source.pileIdx];
+  sourceAfterMove.splice(move.source.cardIdx);
+  if(sourceAfterMove.length && !sourceAfterMove[sourceAfterMove.length - 1].faceUp){
+    sourceAfterMove[sourceAfterMove.length - 1].faceUp = true;
+  }
+
+  const newTopCard = sourceAfterMove[sourceAfterMove.length - 1] || null;
+  const canMoveToFoundation = !!(
+    newTopCard &&
+    newTopCard.faceUp &&
+    gameState.foundations.some(pile => canFoundation(newTopCard, pile))
+  );
+
+  const canMoveToTableau = !!(
+    newTopCard &&
+    newTopCard.faceUp &&
+    simulatedTableau.some((pile, pileIdx) => {
+      if(pileIdx === move.source.pileIdx || !pile.length) return false;
+      return canTableau(newTopCard, pile[pile.length - 1]);
+    })
+  );
+
+  let heuristicScore = 0;
+  if(revealsFaceDown) heuristicScore += 100;
+  heuristicScore += Math.max(0, 20 - movingLength * 3);
+  if(canMoveToFoundation) heuristicScore += 60;
+  if(canMoveToTableau) heuristicScore += 40;
+
+  return heuristicScore;
+}
+
 function selectHintMove(moves){
   if(!moves.length) return null;
   const nonReverseMoves = moves.filter(move => !isImmediateReverse(move, recentMoveContext));
   const candidates = nonReverseMoves.length ? nonReverseMoves : moves;
 
   return candidates
-    .map((move, index) => ({ move, score: scoreHintMove(move), index }))
-    .sort((a, b) => a.score - b.score || a.index - b.index)[0].move;
+    .map((move, index) => ({
+      move,
+      score: scoreHintMove(move),
+      heuristic: scoreEmptyTableauKingHeuristic(move),
+      index
+    }))
+    .sort((a, b) => a.score - b.score || b.heuristic - a.heuristic || a.index - b.index)[0].move;
 }
 
 function runHintRegressionScenario(){
@@ -1907,6 +1961,51 @@ function runHintRegressionScenario(){
   console.assert(hasFollowupProgressMove, 'Free-cell unlock should expose a follow-up king-to-empty-tableau move.');
   console.assert(hasFindAnyMoveHint, 'findAnyMove(true) should return a hint for the unlock chain scenario.');
   console.assert(hasHintCandidate, 'Hint selection should not report "No suggestions found" for the unlock chain scenario.');
+
+  const twoKingDecisionState = {
+    tableau: [
+      [
+        { suit: '♣', rank: '5', value: 5, faceUp: false },
+        { suit: '♣', rank: 'K', value: 13, faceUp: true }
+      ],
+      [
+        { suit: '♥', rank: '7', value: 7, faceUp: true },
+        { suit: '♦', rank: 'K', value: 13, faceUp: true }
+      ],
+      [
+        { suit: '♥', rank: '8', value: 8, faceUp: true }
+      ],
+      [], [], [], []
+    ],
+    hand: [null],
+    foundations: [[], [], [], []]
+  };
+
+  const twoKingDecisionMoves = enumerateMoves({ includeCellShuffles: true, state: twoKingDecisionState });
+  const twoKingDecisionChoice = (() => {
+    const prevTableau = tableau;
+    const prevHand = hand;
+    const prevFoundations = foundations;
+    try {
+      tableau = twoKingDecisionState.tableau.map(pile => pile.map(card => ({ ...card })));
+      hand = [...twoKingDecisionState.hand];
+      foundations = twoKingDecisionState.foundations.map(pile => pile.map(card => ({ ...card })));
+      return selectHintMove(twoKingDecisionMoves);
+    } finally {
+      tableau = prevTableau;
+      hand = prevHand;
+      foundations = prevFoundations;
+    }
+  })();
+
+  const choosesUnlockingKing = !!(
+    twoKingDecisionChoice &&
+    twoKingDecisionChoice.type === 'pile_to_tableau' &&
+    twoKingDecisionChoice.source.pileIdx === 0 &&
+    twoKingDecisionChoice.target.targetCardIdx === null
+  );
+
+  console.assert(choosesUnlockingKing, 'When two kings can move to an empty tableau, hint should choose the one that unlocks follow-up play.');
 }
 
 


### PR DESCRIPTION
### Motivation
- Improve hint selection when moving a King to an empty tableau by preferring moves that reveal facedown cards, move shorter stacks, or expose a newly-playable source card for immediate follow-up play.
- Preserve the existing move-type priority map as the primary ordering and apply the new criteria as a secondary tie-breaker so overall heuristics remain stable.

### Description
- Added `scoreEmptyTableauKingHeuristic(move, gameState)` to compute a secondary heuristic for `hand_to_tableau`/`pile_to_tableau` moves with `targetCardIdx === null` that rewards revealing facedown cards, shorter moved stacks, and exposing a source card that can move to foundation/tableau. 
- Updated `selectHintMove` to include the new `heuristic` value and to sort candidates by `score` (existing priority), then by `heuristic`, then by stable `index` (`a.index - b.index`).
- Added a regression scenario in `runHintRegressionScenario` that constructs a two-King decision state and asserts via `console.assert` that the hint chooser picks the King which unlocks follow-up play.

### Testing
- Searched the codebase for the new symbols with `rg` and confirmed the new function and references exist (searches succeeded).
- Verified the file was modified and committed successfully with `git commit` (commit succeeded).
- Added inline `console.assert` checks in `runHintRegressionScenario` to validate the two-King selection when that scenario is executed in future automated runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a406a2ac832fb6c456c6ae6150f2)