### PR TITLE
fix(game): default new sessions to 3-cell tableau

### DIFF
--- a/index.html
+++ b/index.html
@@ -842,6 +842,7 @@ const SUIT_STYLE_KEY = "rs_suitStyle_v1";
 const GAME_STATE_KEY = "rs_gameState_v1";
 const STATS_HISTORY_KEY = "rs_statsHistory_v1";
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
+const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100;
 const APP_VERSION = "v0.2.12";
 
@@ -908,10 +909,10 @@ const DEAL_VARIANTS = {
   }
 };
 
-let currentDealVariantKey = "cells3";
+let currentDealVariantKey = DEFAULT_DEAL_VARIANT_KEY;
 
 function getDealVariantConfig(variantKey){
-  return DEAL_VARIANTS[variantKey] || DEAL_VARIANTS.cells3;
+  return DEAL_VARIANTS[variantKey] || DEAL_VARIANTS[DEFAULT_DEAL_VARIANT_KEY];
 }
 
 function getCurrentDealConfig(){
@@ -921,8 +922,13 @@ function getCurrentDealConfig(){
 function loadDealVariantPreference(){
   try {
     const saved = localStorage.getItem(DEAL_VARIANT_KEY);
-    if(saved && DEAL_VARIANTS[saved]) currentDealVariantKey = saved;
+    if(saved && DEAL_VARIANTS[saved]){
+      currentDealVariantKey = saved;
+      return;
+    }
   } catch(e) {}
+
+  currentDealVariantKey = DEFAULT_DEAL_VARIANT_KEY;
 }
 
 function applyDealVariant(variantKey){
@@ -1043,7 +1049,7 @@ function loadPersistedGameState(){
 
     const persistedVariantKey = parsed.currentDealVariantKey && DEAL_VARIANTS[parsed.currentDealVariantKey]
       ? parsed.currentDealVariantKey
-      : (parsed.hand.length >= 0 && parsed.hand.length <= 4 ? `cells${parsed.hand.length}` : "cells3");
+      : (parsed.hand.length >= 0 && parsed.hand.length <= 4 ? `cells${parsed.hand.length}` : DEFAULT_DEAL_VARIANT_KEY);
     applyDealVariant(persistedVariantKey);
 
     const expectedFreeCells = getCurrentDealConfig().freeCells;


### PR DESCRIPTION
## Summary
- Added a single `DEFAULT_DEAL_VARIANT_KEY` constant and wired deal-variant fallbacks to it.
- Ensured `loadDealVariantPreference()` explicitly resets to the 3-cell variant when no valid saved preference exists.
- Updated persisted-state fallback logic to use the same default constant.

## Why
This guarantees first-time visitors (or users with invalid/missing saved settings) see the 3-cell custom tableau by default.

## Testing
- Static inspection only (no runtime tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a9e10154832faa5bac3cd06d8434)