### PR TITLE
fix(hints): split legal and practical move availability

### DIFF
--- a/index.html
+++ b/index.html
@@ -763,8 +763,8 @@ header .controls > *{ flex: 0 0 auto; }
 
   <div id="modalLose" class="modal-overlay">
     <div class="modal-box">
-      <h2 style="color:#b71c1c">Out of Moves</h2>
-      <p>The cards have won this round.</p>
+      <h2 id="modalLoseTitle" style="color:#b71c1c">Out of Moves</h2>
+      <p id="modalLoseMessage">The cards have won this round.</p>
       <div class="modal-actions">
         <button onclick="undo()">Undo</button>
         <button onclick="start()">New Game</button>
@@ -1625,8 +1625,21 @@ function classifyHintBranches({ includeAllCellMoves=false, depthLimit=4, nodeCap
 
 function showHint(){
   clearHints();
-  if(findAnyMove(true)) return;
-  alert("No suggestions found.");
+  const moveState = getMoveAvailabilityState();
+
+  if(moveState.hasPracticalMoves){
+    findAnyMove(true);
+    return;
+  }
+
+  if(!moveState.hasLegalMoves){
+    announceHint('No legal moves available.');
+    alert('No legal moves available.');
+    return;
+  }
+
+  announceHint('No practical moves found; try undo/new game.');
+  alert('No practical moves found; try undo/new game.');
 }
 
 function canFinalizeLoss(){
@@ -1650,12 +1663,52 @@ function checkGameState(){
     recordGameResult('win');
     document.getElementById('modalWin').classList.add('active');
   } else {
-    // Check for loss (no moves possible)
-    if(!findAnyMove(false, { includeAllCellMoves: true })){
+    const moveState = getMoveAvailabilityState();
+
+    if(!moveState.hasLegalMoves){
       if(canFinalizeLoss()) recordGameResult('loss');
+      setLoseModalContent({
+        title: 'Out of Moves',
+        message: 'No legal moves remain.'
+      });
       document.getElementById('modalLose').classList.add('active');
+      return;
+    }
+
+    if(!moveState.hasPracticalMoves){
+      announceHint('No practical moves remain. Try undo or start a new game.');
     }
   }
+}
+
+function getMoveAvailabilityState({ state=null } = {}){
+  const gameState = state || { tableau, hand, foundations };
+  const legalMoves = enumerateMoves({
+    includeCellShuffles: true,
+    includeAllCellMoves: true,
+    state: gameState
+  });
+
+  const practicalMovePool = enumerateMoves({
+    includeCellShuffles: true,
+    state: gameState
+  });
+  const nonLoopMoves = practicalMovePool.filter(move => !isImmediateReverse(move, recentMoveContext, gameState));
+  const practicalMoves = nonLoopMoves.length ? nonLoopMoves : [];
+
+  return {
+    hasLegalMoves: legalMoves.length > 0,
+    hasPracticalMoves: practicalMoves.length > 0,
+    legalMoves,
+    practicalMoves
+  };
+}
+
+function setLoseModalContent({ title, message }){
+  const titleEl = document.getElementById('modalLoseTitle');
+  const messageEl = document.getElementById('modalLoseMessage');
+  if(titleEl) titleEl.textContent = title;
+  if(messageEl) messageEl.textContent = message;
 }
 
 function enumerateMoves({ includeCellShuffles=true, includeAllCellMoves=false, suppressImmediateReverse=null, state=null } = {}){
@@ -2194,6 +2247,34 @@ function runHintRegressionScenario(){
   );
 
   console.assert(choosesUnlockingKing, 'When two kings can move to an empty tableau, hint should choose the one that unlocks follow-up play.');
+
+  const noPracticalMovesState = {
+    tableau: [
+      [{ suit: '♠', rank: 'Q', value: 12, faceUp: true }],
+      [{ suit: '♥', rank: 'K', value: 13, faceUp: true }],
+      [], [], [], [], []
+    ],
+    hand: [null],
+    foundations: [[], [], [], []]
+  };
+
+  const noPracticalRecentMove = {
+    type: 'pile_to_tableau',
+    source: { pileIdx: 0, cardIdx: 0 },
+    target: { pileIdx: 1, targetCardIdx: 0 },
+    cardKey: 'Q♠'
+  };
+
+  const previousNoPracticalRecentMoveContext = recentMoveContext;
+  const previousNoPracticalPriorMoveContext = priorMoveContext;
+  recentMoveContext = noPracticalRecentMove;
+  priorMoveContext = null;
+  const noPracticalMoveState = getMoveAvailabilityState({ state: noPracticalMovesState });
+  recentMoveContext = previousNoPracticalRecentMoveContext;
+  priorMoveContext = previousNoPracticalPriorMoveContext;
+
+  console.assert(noPracticalMoveState.hasLegalMoves, 'Reverse-only scenario should still report legal moves.');
+  console.assert(!noPracticalMoveState.hasPracticalMoves, 'Reverse-only scenario should report no practical moves.');
 }
 
 
@@ -2608,6 +2689,10 @@ document.getElementById("undoBtn").onclick = undo;
 document.getElementById("autoBtn").onclick = autoPlay;
 document.getElementById("giveUpBtn").onclick = () => {
   if(hasActiveRunToRecordAsLoss() && !runResultRecorded) recordGameResult('loss');
+  setLoseModalContent({
+    title: 'Out of Moves',
+    message: 'The cards have won this round.'
+  });
   document.getElementById('modalLose').classList.add('active');
 };
 document.getElementById("statsBtn").onclick = () => {


### PR DESCRIPTION
### Motivation
- Make game-over and hint messaging explicit by separating raw legal-move detection from the heuristic/practical hint candidate set so loop-avoidance does not hide legal moves. 
- Surface a distinct non-loss “no practical moves” state so the UI can suggest undo/new-game without immediately treating cyclical-only positions as hard losses. 

### Description
- Add `getMoveAvailabilityState()` to compute `hasLegalMoves` using `enumerateMoves({ includeAllCellMoves: true })` and `hasPracticalMoves` from the non-loop/prioritized hint candidate pool. 
- Update `checkGameState()` to use `getMoveAvailabilityState()` and show a hard loss path when `!hasLegalMoves` and a separate no-practical-moves announcement when legal but impractical moves remain. 
- Update `showHint()` to announce and alert distinct messages for `No legal moves available.` and `No practical moves found; try undo/new game.` while still using existing hint selection logic. 
- Add `modalLose` title/message element IDs and `setLoseModalContent()` to allow state-specific modal copy, and extend `runHintRegressionScenario()` with a reverse-only scenario asserting `hasLegalMoves === true` and `hasPracticalMoves === false`. 

### Testing
- Ran an inline-JS syntax validation by extracting scripts and running `node --check` (via a small `python` wrapper) and it completed successfully. 
- Ran repository whitespace/lint checks via `git diff --check` which reported no issues. 
- Attempted to exercise runtime assertions in the page with Playwright to verify `runHintRegressionScenario()` but the browser load failed with `ERR_FILE_NOT_FOUND` so page-level assertions were not executed in CI; the `console.assert` checks remain in-source for runtime validation when the page is loaded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b5177f18832f89a659f87779561b)