### PR TITLE
fix(index): run hint regression only in debug mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -2633,7 +2633,12 @@ try {
 
 loadDealVariantPreference();
 applyDealVariant(currentDealVariantKey);
-runHintRegressionScenario();
+// Use ?debug=1 to enable runtime hint regression assertions.
+const isDebugMode = new URLSearchParams(location.search).get('debug') === '1' || ['localhost','127.0.0.1'].includes(location.hostname);
+if(isDebugMode){
+  console.info('[debug] Hint regression assertions enabled.');
+  runHintRegressionScenario();
+}
 
 if(loadPersistedGameState()){
   startTimer();


### PR DESCRIPTION
### Motivation
- Prevent runtime hint-regression assertions from running for production users by gating them behind a debug/dev-only check.

### Description
- Add a small startup helper `isDebugMode` with the comment `Use ?debug=1 to enable runtime hint regression assertions` that checks `?debug=1` or `localhost`/`127.0.0.1` and use it to conditionally call `runHintRegressionScenario()`.
- Log a one-time `console.info` when the debug path is active so assertions can be confirmed during development.

### Testing
- Ran `rg -n "runHintRegressionScenario|initializ|debug" index.html` to validate the occurrence and `git diff -- index.html` to inspect the change, both succeeded.
- Verified the file was staged and committed via `git add`/`git commit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b52f2354832fb19929a3edd208e3)