### PR TITLE
fix: allow zoom in viewport meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
 <head>
   <meta charset="UTF-8" />
   <title>Russian Reserve</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <!-- Accessibility: allow browser zoom; revert this line only if severe layout regressions appear. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     :root{
       --header-h: 44px;


### PR DESCRIPTION
### Motivation
- Restore browser zooming for accessibility by removing `maximum-scale=1, user-scalable=no` from the viewport meta, while keeping the change easy to revert if it causes layout regressions.

### Description
- Updated `index.html` to replace `<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />` with `<!-- Accessibility: allow browser zoom; revert this line only if severe layout regressions appear. -->` followed by `<meta name="viewport" content="width=device-width, initial-scale=1" />`.

### Testing
- No runtime tests were required for this static HTML change; verified the update with `git diff -- index.html` and `nl -ba index.html | sed -n '1,20p'`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b53dc878832fae29eb8f825f27ae)