### PR TITLE
fix(hints): align practical-move gating with node-cap fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1693,15 +1693,20 @@ function getMoveAvailabilityState({ state=null } = {}){
     state: gameState
   });
 
-  const { progressBranches } = classifyHintBranches({
+  const branchClassification = classifyHintBranches({
     includeAllCellMoves: false,
     state: gameState
   });
+  const { progressBranches, hitNodeCap } = branchClassification;
   const practicalMoves = progressBranches.map(branch => branch.move);
+  const fallbackPracticalMoves = !practicalMoves.length && hitNodeCap
+    ? legalMoves.filter(move => !isImmediateReverse(move, recentMoveContext, gameState))
+    : [];
+  const hasPracticalMoves = practicalMoves.length > 0 || fallbackPracticalMoves.length > 0;
 
   return {
     hasLegalMoves: legalMoves.length > 0,
-    hasPracticalMoves: practicalMoves.length > 0,
+    hasPracticalMoves,
     legalMoves,
     practicalMoves
   };
@@ -2377,7 +2382,7 @@ function findAnyMove(highlight, { includeAllCellMoves=false } = {}){
   const branchClassification = classifyHintBranches({ includeAllCellMoves, state: gameState });
   let candidateMoves = branchClassification.progressBranches.map(branch => branch.move);
 
-  if(!candidateMoves.length && branchClassification.branches.length === 0 && branchClassification.hitNodeCap){
+  if(!candidateMoves.length && branchClassification.hitNodeCap){
     const nonLoopMoves = moves.filter(move => !isImmediateReverse(move, recentMoveContext, gameState));
     candidateMoves = nonLoopMoves.length ? nonLoopMoves : [];
   }


### PR DESCRIPTION
### Motivation
- Branch exploration can hit `nodeCap` before discovering progress branches, which left `hasPracticalMoves` false and prevented the fallback hint path from being attempted. 
- The change ensures the UI can still present fallback non-loop moves when search was truncated by node limits so users in dense positions receive hints.

### Description
- Updated `getMoveAvailabilityState` in `index.html` to consume the full `classifyHintBranches` result and expose `hitNodeCap` so the availability check can consider fallback candidates. 
- Added computation of `fallbackPracticalMoves` (non-immediate-reverse legal moves) and made `hasPracticalMoves` true when either progress branches or fallback candidates exist. 
- Relaxed the `findAnyMove` fallback guard to trigger on `hitNodeCap` when no progress candidates are found, removing the previous `branches.length === 0` requirement.

### Testing
- Extracted the inline script and ran `node --check /tmp/rezanow_script.js`, which completed successfully. 
- Verified the change via diff and committed the update as `fix(hints): propagate node-cap fallback to move availability`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4bef31a3c832fb3516d7ab72241f2)