### PR TITLE
fix(stats): increase max stats history to 100k

### DIFF
--- a/index.html
+++ b/index.html
@@ -908,7 +908,7 @@ const GAME_STATE_KEY = "rs_gameState_v1";
 const STATS_HISTORY_KEY = "rs_statsHistory_v1";
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
-const MAX_STATS_HISTORY = 100;
+const MAX_STATS_HISTORY = 100000;
 const APP_VERSION = "v0.2.16";
 
 const DEAL_VARIANTS = {


### PR DESCRIPTION
Increases the maximum game history entries retained in `localStorage` from 100 to 100,000. 

**Reasoning:**
The game dynamically calculates lifetime statistics (such as "Total games", "Win rate", and "Streaks") by iterating over the history of completed games stored in `localStorage` under `rs_statsHistory_v1`. A hardcoded cap of 100 was inadvertently restricting these stats to only the *last* 100 games played. Increasing the limit to 100,000 allows for accurate lifetime statistics for basically all users, while still acting as a generous eventual guardrail against `QuotaExceededError` in browser storage. 

**Verification:**
* Verified the issue locally by injecting > 100 mock games into `localStorage`.
* With the previous limit, `history.slice(-MAX_STATS_HISTORY)` would truncate the array to 100 upon save, limiting the total games count to 100.
* After applying the fix, injecting 150 mock games successfully reflected a "Total games" count of 150 in the stats modal UI.

---
*PR created automatically by Jules for task [17366645761893777820](https://jules.google.com/task/17366645761893777820) started by @Rezanow*