### PR TITLE
fix(export): improve export copy fallback handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1443,14 +1443,47 @@ function exportSave() {
   document.getElementById('modalExport').classList.add('active');
 }
 
-function copyExportData() {
+async function copyExportData() {
   const input = document.getElementById('exportSaveData');
-  input.select();
-  document.execCommand('copy');
   const btn = document.getElementById('copyExportBtn');
   const oldText = btn.textContent;
-  btn.textContent = "Copied!";
-  setTimeout(() => btn.textContent = oldText, 2000);
+
+  const setButtonTextTemporarily = (text) => {
+    btn.textContent = text;
+    setTimeout(() => btn.textContent = oldText, 2000);
+  };
+
+  if (!input.value.trim()) {
+    setButtonTextTemporarily("No code yet");
+    return;
+  }
+
+  let copied = false;
+  if (window.isSecureContext && navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    try {
+      await navigator.clipboard.writeText(input.value);
+      copied = true;
+    } catch (e) {
+      copied = false;
+    }
+  }
+
+  if (!copied) {
+    try {
+      input.focus();
+      input.select();
+      input.setSelectionRange(0, input.value.length);
+      copied = document.execCommand('copy');
+    } catch (e) {
+      copied = false;
+    }
+  }
+
+  if (copied) {
+    setButtonTextTemporarily("Copied!");
+  } else {
+    setButtonTextTemporarily("Copy failed");
+  }
 }
 
 function showImportModal() {


### PR DESCRIPTION
### Motivation
- Modernize the export copy flow to prefer the async Clipboard API when available and secure. 
- Preserve compatibility for legacy browsers by retaining the `document.execCommand('copy')` fallback. 
- Improve UX for empty exports and failed copy attempts, and ensure selection/focus behavior is mobile-safe.

### Description
- Made `copyExportData()` async and added a primary copy path using `navigator.clipboard.writeText(input.value)` guarded by `window.isSecureContext` and API availability. 
- Kept `document.execCommand('copy')` as a fallback and added mobile-safe focus/selection via `input.focus()`, `input.select()`, and `input.setSelectionRange(0, input.value.length)`. 
- Added an empty-export guard that shows `No code yet` when the export textarea is empty. 
- Preserved the temporary `Copied!` feedback and added `Copy failed` on failure using a small `setButtonTextTemporarily` helper.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f8d53570832fa6768087a3fde3a1)