### PR TITLE
fix(import): normalize save input before base64 decode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1463,7 +1463,16 @@ function importSave() {
   if (!input) return;
 
   try {
-    const decoded = decodeURIComponent(atob(input));
+    const normalizedInput = (() => {
+      let normalized = input.replace(/\s+/g, '').replace(/-/g, '+').replace(/_/g, '/');
+      const paddingLength = normalized.length % 4;
+      if (paddingLength) {
+        normalized += '='.repeat(4 - paddingLength);
+      }
+      return normalized;
+    })();
+
+    const decoded = decodeURIComponent(atob(normalizedInput));
     const parsed = JSON.parse(decoded);
 
     let gameStateToImport = null;
@@ -1502,7 +1511,7 @@ function importSave() {
     location.reload();
 
   } catch (e) {
-    alert("Invalid save data. Please check the code and try again.");
+    alert("Invalid save data. Please check the code, try pasting again, or use the Copy button.");
   }
 }
 


### PR DESCRIPTION
### Motivation
- Normalize pasted save strings before decoding to handle URL-safe base64, stray whitespace/newlines, and missing padding and to reduce mobile paste failures while clarifying the import error message.

### Description
- Update `importSave()` to normalize `input` by removing whitespace with `input.replace(/\s+/g, '')`, converting `-` to `+` and `_` to `/`, restoring `=` padding based on `length % 4`, then `atob`/`decodeURIComponent` the normalized string and continue the existing `JSON.parse`/validation/import flow unchanged, and update the import failure `alert` to suggest trying to paste again or using the Copy button.

### Testing
- No automated tests were run for this small client-side change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f8d5c470832fb9968ce4055e6bba)