### PR TITLE
fix(ui): disable autocorrect on save data textareas

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,7 +792,7 @@ header .controls > *{ flex: 0 0 auto; }
     <div class="modal-box" style="max-width: 400px; width: 90%; background: #ffffff; color: #111;">
       <h2>Export Save Data</h2>
       <p style="font-size: 13px;">Copy this code to transfer your progress to another device.</p>
-      <textarea id="exportSaveData" readonly style="width: 100%; height: 80px; margin-bottom: 10px; font-size: 11px; resize: none; color: #111; background: #fff;"></textarea>
+      <textarea id="exportSaveData" readonly autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" inputmode="text" style="width: 100%; height: 80px; margin-bottom: 10px; font-size: 11px; resize: none; color: #111; background: #fff;"></textarea>
       <div class="modal-actions">
         <button id="copyExportBtn" onclick="copyExportData()">Copy</button>
         <button onclick="closeExportModal()">Close</button>
@@ -804,7 +804,7 @@ header .controls > *{ flex: 0 0 auto; }
     <div class="modal-box" style="max-width: 400px; width: 90%; background: #ffffff; color: #111;">
       <h2>Import Save Data</h2>
       <p style="font-size: 13px;">Paste a previously exported save code here.</p>
-      <textarea id="importSaveData" style="width: 100%; height: 80px; margin-bottom: 10px; font-size: 11px; resize: none; color: #111; background: #fff;"></textarea>
+      <textarea id="importSaveData" autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" inputmode="text" style="width: 100%; height: 80px; margin-bottom: 10px; font-size: 11px; resize: none; color: #111; background: #fff;"></textarea>
       <div class="modal-actions">
         <button onclick="importSave()">Import</button>
         <button onclick="closeImportModal()">Cancel</button>


### PR DESCRIPTION
### Motivation
- Prevent input helpers (autocapitalize, autocorrect, spellcheck, autocomplete, and numeric keyboard switching) from altering exported/imported save codes in the save-data modals.

### Description
- Added `autocapitalize="off"`, `autocomplete="off"`, `autocorrect="off"`, `spellcheck="false"`, and `inputmode="text"` to `#exportSaveData` and `#importSaveData` in `index.html` and preserved existing inline sizing, styling, and modal behavior.

### Testing
- Confirmed the textarea elements include the new attributes by running `rg -n "id=\"(exportSaveData|importSaveData)\"" index.html` which returned the updated lines.
- Verified the change surface in the working tree with `git diff -- index.html` and committed the update with `git commit`, both completing successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f8d66ce8832f925784eeda9b846b)