### PR TITLE
fix(hints): highlight destination containers in hint flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -2777,14 +2777,37 @@ function findAnyMove(highlight, { includeAllCellMoves=false } = {}){
     if (hintHistory.length > 10) hintHistory.shift();
   }
 
-  if(move.type === 'hand_to_foundation' || move.type === 'hand_to_tableau'){
+  if(move.type === 'hand_to_foundation'){
     highlightHand(move.source.handIdx, 'source');
+    highlightFoundation(move.target.foundationIdx, 'target');
     announceMoveHint(move);
     return true;
   }
 
-  if(move.type === 'pile_to_foundation' || move.type === 'pile_to_tableau' || move.type === 'pile_to_hand'){
+  if(move.type === 'hand_to_tableau'){
+    highlightHand(move.source.handIdx, 'source');
+    highlightPile(move.target.pileIdx, 'target');
+    announceMoveHint(move);
+    return true;
+  }
+
+  if(move.type === 'pile_to_foundation'){
     highlightPileCard(move.source.pileIdx, move.source.cardIdx, 'source');
+    highlightFoundation(move.target.foundationIdx, 'target');
+    announceMoveHint(move);
+    return true;
+  }
+
+  if(move.type === 'pile_to_tableau'){
+    highlightPileCard(move.source.pileIdx, move.source.cardIdx, 'source');
+    highlightPile(move.target.pileIdx, 'target');
+    announceMoveHint(move);
+    return true;
+  }
+
+  if(move.type === 'pile_to_hand'){
+    highlightPileCard(move.source.pileIdx, move.source.cardIdx, 'source');
+    highlightHand(move.target.handIdx, 'target');
     announceMoveHint(move);
     return true;
   }
@@ -2830,6 +2853,7 @@ function highlightPile(idx, type){
 }
 function highlightPileCard(pileIdx, cardIdx, type){ 
   const pile = document.querySelector(`.pile[data-id="${pileIdx}"]`);
+  if(!pile) return;
   const cards = pile.querySelectorAll('.card');
   if(cards[cardIdx]) cards[cardIdx].classList.add('hint-'+type);
 }


### PR DESCRIPTION
### Motivation
- Improve hint UX by making hints visually indicate both source and destination for suggested moves so users can more easily see where a card should go.
- Ensure hint highlighting covers container-level targets (foundations, tableau piles, and hand slots) instead of only card-level highlights to reduce ambiguity.
- Prevent runtime errors when hint logic runs against missing DOM elements during rendering.

### Description
- Updated the hint presentation path in `findAnyMove` to call `highlightFoundation`, `highlightPile`, or `highlightHand` for the corresponding move target types so both source and destination receive `hint-source` / `hint-target` classes.
- Broke out `hand_to_foundation`, `hand_to_tableau`, `pile_to_foundation`, `pile_to_tableau`, and `pile_to_hand` branches to apply explicit source and destination highlighting and still call `announceMoveHint`.
- Added a defensive null check in `highlightPileCard` to avoid querying `.card` on a missing `.pile` element and kept existing `hint-source`/`hint-target` naming and the `clearHints` behavior intact.

### Testing
- Ran targeted searches with `rg` to confirm `highlightFoundation`, `highlightPile`, `hint-target`, and the modified `findAnyMove` branches are present and referenced, which succeeded.
- Verified the git diff and created a commit with `git commit -m "fix(hints): highlight destination containers in hint flow"`, which succeeded.
- Attempted to serve the app (`python3 -m http.server`) and capture a Playwright screenshot to validate runtime highlighting, but the local server/playwright run failed in this execution environment and could not complete.
- No unit tests exist for UI hints in the repo, so changes were validated via static inspection and search-based checks only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a505d2321c832f942c47fd9e3626b1)