### PR TITLE
chore: bump app version to v0.3.0-js

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -11,7 +11,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.18";
+const APP_VERSION = "v0.3.0-js";
 
 const DEAL_VARIANTS = {
   cells0: {

--- a/js/game.js
+++ b/js/game.js
@@ -11,7 +11,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.18";
+const APP_VERSION = "v0.3.0-js";
 
 const DEAL_VARIANTS = {
   cells0: {


### PR DESCRIPTION
### Motivation
- Bump the in-app version constant so the runtime reflects the new release/tag `v0.3.0-js`.

### Description
- Update `APP_VERSION` in `js/app.js` and `js/game.js` from `v0.2.18` to `v0.3.0-js`.

### Testing
- Ran `rg -n "APP_VERSION|v0\.3\.0-js|v0\.2\.18" js/app.js js/game.js` and confirmed `v0.3.0-js` is present and `v0.2.18` no longer appears.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a511b8df84832fa3e7c89da6a1d4e4)