### PR TITLE
fix(bootstrap): initialize game before firebase stats

### DIFF
--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -1,5 +1,5 @@
 import { initFirebaseStats } from "./firebase-init.js";
 import { initGame } from "./game.js";
 
-await initFirebaseStats();
 initGame();
+void initFirebaseStats();


### PR DESCRIPTION
### Motivation
- Ensure gameplay and UI are available immediately by starting the game before any potentially slow or blocked Firebase initialization.

### Description
- Call `initGame()` immediately in `js/bootstrap.js` and start Firebase initialization in the background with `void initFirebaseStats();`, leaving `js/firebase-init.js` error handling unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c7316a44832fbf45c443f9e9ab2d)