### PR TITLE
refactor(ui): move button handlers to initGame listeners

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,7 +671,7 @@ header .controls > *{ flex: 0 0 auto; }
       <button id="menuToggle" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="headerControls">☰</button>
     </div>
     <div class="controls" id="headerControls">
-      <button id="hintBtn" onclick="showHint()">Hint</button>
+      <button id="hintBtn">Hint</button>
       <span id="hintAnnouncement" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></span>
       
       <label class="suit-style-label" for="suitStyleSelect">Suit Style:</label>
@@ -702,8 +702,8 @@ header .controls > *{ flex: 0 0 auto; }
       
       <button id="rulesBtn" title="View rules">Rules</button>
       <button id="statsBtn" title="View stats">Stats</button>
-      <button id="exportBtn" onclick="exportSave()">Export Save</button>
-      <button id="importBtn" onclick="showImportModal()">Import Save</button>
+      <button id="exportBtn">Export Save</button>
+      <button id="importBtn">Import Save</button>
       <button id="autoBtn">Auto</button>
       <button id="giveUpBtn">Give Up</button>
       <button id="undoBtn">Undo</button>
@@ -761,7 +761,7 @@ header .controls > *{ flex: 0 0 auto; }
       <h2>Victory!</h2>
       <p>You have conquered the cards.</p>
       <div class="modal-actions">
-        <button onclick="start()">Play Again</button>
+        <button id="playAgainBtn">Play Again</button>
       </div>
     </div>
   </div>
@@ -771,8 +771,8 @@ header .controls > *{ flex: 0 0 auto; }
       <h2 id="modalLoseTitle" style="color:#b71c1c">Out of Moves</h2>
       <p id="modalLoseMessage">The cards have won this round.</p>
       <div class="modal-actions">
-        <button onclick="undo()">Undo</button>
-        <button onclick="start()">New Game</button>
+        <button id="loseUndoBtn">Undo</button>
+        <button id="newGameBtn">New Game</button>
       </div>
     </div>
   </div>
@@ -794,8 +794,8 @@ header .controls > *{ flex: 0 0 auto; }
       <p style="font-size: 13px;">Copy this code to transfer your progress to another device.</p>
       <textarea id="exportSaveData" readonly autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" inputmode="text" style="width: 100%; height: 80px; margin-bottom: 10px; font-size: 11px; resize: none; color: #111; background: #fff;"></textarea>
       <div class="modal-actions">
-        <button id="copyExportBtn" onclick="copyExportData()">Copy</button>
-        <button onclick="closeExportModal()">Close</button>
+        <button id="copyExportBtn">Copy</button>
+        <button id="closeExportBtn">Close</button>
       </div>
     </div>
   </div>
@@ -806,8 +806,8 @@ header .controls > *{ flex: 0 0 auto; }
       <p style="font-size: 13px;">Paste a previously exported save code here.</p>
       <textarea id="importSaveData" autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" inputmode="text" style="width: 100%; height: 80px; margin-bottom: 10px; font-size: 11px; resize: none; color: #111; background: #fff;"></textarea>
       <div class="modal-actions">
-        <button onclick="importSave()">Import</button>
-        <button onclick="closeImportModal()">Cancel</button>
+        <button id="confirmImportBtn">Import</button>
+        <button id="cancelImportBtn">Cancel</button>
       </div>
     </div>
   </div>

--- a/js/game.js
+++ b/js/game.js
@@ -2289,6 +2289,16 @@ function scheduleFit(){
 export function initGame(){
 document.getElementById("undoBtn").onclick = undo;
 document.getElementById("autoBtn").onclick = autoPlay;
+document.getElementById("hintBtn").addEventListener('click', showHint);
+document.getElementById("exportBtn").addEventListener('click', exportSave);
+document.getElementById("importBtn").addEventListener('click', showImportModal);
+document.getElementById("playAgainBtn").addEventListener('click', start);
+document.getElementById("loseUndoBtn").addEventListener('click', undo);
+document.getElementById("newGameBtn").addEventListener('click', start);
+document.getElementById("copyExportBtn").addEventListener('click', copyExportData);
+document.getElementById("closeExportBtn").addEventListener('click', closeExportModal);
+document.getElementById("confirmImportBtn").addEventListener('click', importSave);
+document.getElementById("cancelImportBtn").addEventListener('click', closeImportModal);
 document.getElementById("giveUpBtn").onclick = () => {
   if(hasActiveRunToRecordAsLoss() && !runResultRecorded) recordGameResult('loss');
   setLoseModalContent({


### PR DESCRIPTION
### Motivation
- Remove inline `onclick` attributes to avoid mixing inline handlers with JS listeners and enable using module scripts safely.
- Consolidate all control and modal button wiring in `initGame()` so event bindings are stable and discoverable.

### Description
- Removed inline `onclick` attributes from header controls and modal action buttons in `index.html` and added stable IDs where needed (`playAgainBtn`, `loseUndoBtn`, `newGameBtn`, `closeExportBtn`, `confirmImportBtn`, `cancelImportBtn`).
- Wired the affected controls in `initGame()` using `addEventListener` for `hintBtn` → `showHint`, `exportBtn` → `exportSave`, `importBtn` → `showImportModal`, `playAgainBtn` → `start`, `loseUndoBtn` → `undo`, `newGameBtn` → `start`, `copyExportBtn` → `copyExportData`, `closeExportBtn` → `closeExportModal`, `confirmImportBtn` → `importSave`, and `cancelImportBtn` → `closeImportModal`.
- Kept existing programmatic bindings for other buttons and ensured a consistent event-binding style for the modified controls.

### Testing
- Ran `rg -n 'onclick="' index.html js/game.js` and confirmed there are no remaining inline `onclick` occurrences in the targeted files.
- Inspected the updated `index.html` and `js/game.js` to verify the new IDs and that `initGame()` registers the intended listeners, with the checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c7302f84832fa1acd9c33027790a)