### PR TITLE
chore(version): bump patch version

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -11,7 +11,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.3.0-js";
+const APP_VERSION = "v0.3.1-js";
 
 const DEAL_VARIANTS = {
   cells0: {

--- a/js/game.js
+++ b/js/game.js
@@ -11,7 +11,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.3.0-js";
+const APP_VERSION = "v0.3.1-js";
 
 const DEAL_VARIANTS = {
   cells0: {


### PR DESCRIPTION
### Motivation
- Bump the app patch version so the runtime constant and the UI-displayed version remain in sync.

### Description
- Updated the `APP_VERSION` constant from `v0.3.0-js` to `v0.3.1-js` in `js/app.js` and `js/game.js`.

### Testing
- Ran `rg -n "APP_VERSION" js/app.js js/game.js` and served the site with `python -m http.server 4173` then captured a Playwright screenshot to confirm the footer shows the new version; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c811f734832f85c96ace3718ad0c)