### PR TITLE
fix(ci): include js modules in release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p build
+          cp -R js build/js
           cp index.html build/index.html
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: site-build
-          path: build/index.html
+          path: build/


### PR DESCRIPTION
### Motivation
- Ensure `index.html` and the module files under `js/` are packaged and deployed together so relative imports like `js/bootstrap.js` resolve correctly and do not return HTML fallback pages.

### Description
- Update `.github/workflows/release.yml` `Prepare build artifact` step to copy `js/` into `build/js` and upload the full `build/` directory while keeping `index.html` at `build/index.html`.

### Testing
- Ran the workflow-equivalent steps locally (`cp -R js build/js && cp index.html build/index.html`), served `build/` with `python3 -m http.server --directory build`, and used `curl -I` to verify `js/bootstrap.js`, `js/game.js`, and `js/firebase-init.js` returned `200 OK` with `Content-type: text/javascript`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c9339e78832fae1973353175426e)