### PR TITLE
fix: clear hint highlights before tap auto-move paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -2936,6 +2936,7 @@ function handleTouchEnd(e){
     lastTouchEndTs = Date.now();
   } else {
     e.preventDefault();
+    clearHints();
     if(tryAutoMoveFromTap(dragSource.type, dragSource.idx, dragSource.cardIdx)){
       selected = null;
       render();
@@ -3046,6 +3047,7 @@ function createCardEl(c, type, idx, cardIdx){
       e.preventDefault();
       return;
     }
+    clearHints();
     if(tryAutoMoveFromTap(type, idx, cardIdx)){
       selected = null;
       render();


### PR DESCRIPTION
### Motivation
- Ensure hint outlines (`.hint-source`/`.hint-target`) are cleared immediately when a click/tap triggers an automatic early-return move so visual hints do not persist after the move.

### Description
- Inserted `clearHints()` in `handleTouchEnd(e)` non-drag branch immediately before `tryAutoMoveFromTap(...)`.
- Inserted `clearHints()` in `createCardEl(...).onclick` immediately before `tryAutoMoveFromTap(...)`.
- Changes applied in `index.html` (two small insertions to align click and touch tap behavior).

### Testing
- Ran `git diff -- index.html` to verify the edits were applied and the diff shows the `clearHints()` insertions (succeeded).
- Inspected the modified region with `nl -ba index.html | sed -n '2928,3058p'` to confirm the `clearHints()` calls appear before `tryAutoMoveFromTap(...)` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61ecb4a14832fb2236adc834e3e72)