### PR TITLE
chore: bump index patch version to v0.2.20

### DIFF
--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.19";
+const APP_VERSION = "v0.2.20";
 
 const DEAL_VARIANTS = {
   cells0: {


### PR DESCRIPTION
## Summary
- bump the in-app `APP_VERSION` constant in `index.html`
- update version from `v0.2.19` to `v0.2.20`

## Testing
- not run (version string update only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a62214f050832fba69743bab005079)