### PR TITLE
fix(touch): distinguish pan intent from card drag

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
       border: 1px solid #bbb;
       z-index: 10;
       transition: transform 0.1s;
-      touch-action: none;
+      touch-action: pan-y;
     }
     .card:active { transform: scale(0.96); }
     .card.back {
@@ -910,7 +910,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.20";
+const APP_VERSION = "v0.2.21";
 
 const DEAL_VARIANTS = {
   cells0: {
@@ -2850,8 +2850,14 @@ function highlightPileCard(pileIdx, cardIdx, type){
 let dragSource = null;
 let lastTouchEndTs = 0;
 const TOUCH_CLICK_GUARD_MS = 400;
+const TOUCH_DRAG_DISTANCE_PX = 10;
+const TOUCH_PAN_DISTANCE_PX = 10;
+const TOUCH_PAN_DOMINANCE_RATIO = 1.2;
+const TOUCH_DRAG_HOLD_MS = 140;
 let touchClone = document.getElementById('drag-ghost');
 let touchStartCoords = {x:0, y:0};
+let touchStartTs = 0;
+let touchIntent = 'none';
 let isDragGesture = false;
 let touchOriginalEl = null;
 
@@ -2878,12 +2884,22 @@ function handleDrop(e, targetType, targetIdx){
   commitMove(targetType, targetIdx);
 }
 
+function resetTouchInteraction(){
+  if(touchOriginalEl) touchOriginalEl.classList.remove('dragging');
+  dragSource = null;
+  touchIntent = 'none';
+  isDragGesture = false;
+  touchOriginalEl = null;
+  touchClone.style.display = 'none';
+}
+
 function handleTouchStart(e, type, idx, cardIdx){
   clearHints();
   if(type === 'pile' && !tableau[idx][cardIdx].faceUp) return;
-  e.preventDefault();
   const touch = e.touches[0];
   touchStartCoords = {x: touch.clientX, y: touch.clientY};
+  touchStartTs = Date.now();
+  touchIntent = 'pending';
   isDragGesture = false;
   dragSource = { type, idx, cardIdx };
   touchOriginalEl = e.target.closest('.card');
@@ -2891,26 +2907,44 @@ function handleTouchStart(e, type, idx, cardIdx){
 function handleTouchMove(e){
   if(!dragSource) return;
   const touch = e.touches[0];
-  const dist = Math.sqrt(Math.pow(touch.clientX - touchStartCoords.x, 2) + Math.pow(touch.clientY - touchStartCoords.y, 2));
-  if(dist > 10 && !isDragGesture){
+  const dx = touch.clientX - touchStartCoords.x;
+  const dy = touch.clientY - touchStartCoords.y;
+  const absX = Math.abs(dx);
+  const absY = Math.abs(dy);
+  const dist = Math.hypot(dx, dy);
+  const elapsedMs = Date.now() - touchStartTs;
+
+  if(!isDragGesture){
+    const isPanIntent = absY > TOUCH_PAN_DISTANCE_PX && absY > (absX * TOUCH_PAN_DOMINANCE_RATIO);
+    if(isPanIntent){
+      resetTouchInteraction();
+      return;
+    }
+
+    const isNonVerticalMove = absX >= absY;
+    const shouldStartDrag = dist > TOUCH_DRAG_DISTANCE_PX && (elapsedMs >= TOUCH_DRAG_HOLD_MS || isNonVerticalMove);
+    if(!shouldStartDrag) return;
+
+    touchIntent = 'drag';
     isDragGesture = true;
     const original = touchOriginalEl || e.target.closest('.card');
     if(original){
-        const rect = original.getBoundingClientRect();
-        touchClone.replaceChildren(original.cloneNode(true));
-        touchClone.className = "card";
-        touchClone.style.width = rect.width + "px";
-        touchClone.style.height = rect.height + "px";
-        touchClone.style.color = original.style.color;
-        touchClone.style.background = original.style.background;
-        touchClone.style.display = "block";
-        original.classList.add('dragging');
+      const rect = original.getBoundingClientRect();
+      touchClone.replaceChildren(original.cloneNode(true));
+      touchClone.className = "card";
+      touchClone.style.width = rect.width + "px";
+      touchClone.style.height = rect.height + "px";
+      touchClone.style.color = original.style.color;
+      touchClone.style.background = original.style.background;
+      touchClone.style.display = "block";
+      original.classList.add('dragging');
     }
   }
+
   if(isDragGesture){
-     e.preventDefault();
-     touchClone.style.left = (touch.clientX - 20) + "px";
-     touchClone.style.top = (touch.clientY - 20) + "px";
+    e.preventDefault();
+    touchClone.style.left = (touch.clientX - 20) + "px";
+    touchClone.style.top = (touch.clientY - 20) + "px";
   }
 }
 function handleTouchEnd(e){
@@ -2929,7 +2963,11 @@ function handleTouchEnd(e){
       commitMove(tType, tIdx);
     } else render();
     lastTouchEndTs = Date.now();
-  } else {
+    resetTouchInteraction();
+    return;
+  }
+
+  if(touchIntent === 'pending'){
     e.preventDefault();
     clearHints();
     if(tryAutoMoveFromTap(dragSource.type, dragSource.idx, dragSource.cardIdx)){
@@ -2941,9 +2979,7 @@ function handleTouchEnd(e){
     }
     lastTouchEndTs = Date.now();
   }
-  dragSource = null;
-  isDragGesture = false;
-  touchOriginalEl = null;
+  resetTouchInteraction();
 }
 
 function commitMove(targetType, targetIdx){
@@ -3035,6 +3071,7 @@ function createCardEl(c, type, idx, cardIdx){
   el.ontouchstart = (e) => handleTouchStart(e, type, idx, cardIdx);
   el.ontouchmove = handleTouchMove;
   el.ontouchend = handleTouchEnd;
+  el.ontouchcancel = resetTouchInteraction;
   el.onclick = (e) => {
     if(Date.now() - lastTouchEndTs < TOUCH_CLICK_GUARD_MS) return;
     e.stopPropagation();


### PR DESCRIPTION
## Summary
- switched card touch behavior to preserve vertical scroll (`touch-action: pan-y`)
- implemented touch intent detection so gestures start in a pending state and resolve to pan vs drag based on movement direction, distance, and hold timing
- removed unconditional `preventDefault()` on touch start so browser scrolling can begin naturally
- added touch interaction reset handling (`resetTouchInteraction`) and bound `ontouchcancel` to avoid stuck drag visuals
- bumped app version in `index.html` from `v0.2.20` to `v0.2.21`

## Testing
- Not run (no lightweight automated test target for this touch interaction change in this repo)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71f755b38832f96ba8df3a547e254)