### PR TITLE
refactor(hints): tiered fallback candidates in findAnyMove

### DIFF
--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.21";
+const APP_VERSION = "v0.2.22";
 
 const DEAL_VARIANTS = {
   cells0: {
@@ -2748,14 +2748,24 @@ function runHintRegressionScenario(){
 
 function findAnyMove(highlight, { includeAllCellMoves=false } = {}){
   const gameState = { tableau, hand, foundations };
-  const moves = enumerateMoves({ includeCellShuffles: true, includeAllCellMoves });
   const branchClassification = classifyHintBranches({ includeAllCellMoves, state: gameState });
-  let candidateMoves = branchClassification.progressBranches.map(branch => branch.move);
+  const tier1Moves = branchClassification.progressBranches.map(branch => branch.move);
+  const legalMoves = enumerateMoves({ includeCellShuffles: true, includeAllCellMoves: true });
+  const tier2Moves = legalMoves.filter(move => {
+    if(isImmediateReverse(move, recentMoveContext, gameState)) return false;
+    if(isHintLoop(move, gameState)) return false;
+    return true;
+  });
+  const tier3Moves = legalMoves.filter(move => !isImmediateReverse(move, recentMoveContext, gameState));
+  const tier4Moves = legalMoves;
 
-  if(!candidateMoves.length && branchClassification.hitNodeCap){
-    const nonLoopMoves = moves.filter(move => !isImmediateReverse(move, recentMoveContext, gameState));
-    candidateMoves = nonLoopMoves.length ? nonLoopMoves : [];
-  }
+  const candidateMoves = tier1Moves.length
+    ? tier1Moves
+    : tier2Moves.length
+      ? tier2Moves
+      : tier3Moves.length
+        ? tier3Moves
+        : tier4Moves;
 
   const move = selectHintMove(candidateMoves, { gameState, recentMove: recentMoveContext, priorMove: priorMoveContext });
   if(!move) return false;


### PR DESCRIPTION
### Motivation
- Avoid returning no hint candidates when `progressBranches` are empty and provide progressively looser fallback sets so hints can still be offered.
- Ensure fallback enumeration includes cell transitions so cell-related moves are not missed by the fallback logic.
- Preserve existing hint scoring and selection so strategic ordering remains unchanged.

### Description
- Implemented a four-tier candidate selection in `findAnyMove`: Tier 1 uses `progressBranches.map(branch => branch.move)`, Tier 2 uses legal moves excluding immediate reverses and `isHintLoop`, Tier 3 excludes only immediate reverses, and Tier 4 is raw legal moves as a last resort.
- Use `enumerateMoves({ includeCellShuffles: true, includeAllCellMoves: true })` for fallback tiers to include cell transitions.
- Pass the chosen tier to `selectHintMove(...)` and retain existing scoring/heuristics (`scoreHintMove`, `scoreMove`, king heuristic) by leaving downstream selection unchanged.
- Bumped application patch version from `v0.2.21` to `v0.2.22` in `index.html` to satisfy repo versioning rules.

### Testing
- Ran `node test-hint-loop.js`, which failed in this environment due to missing Playwright browser binaries (error: requested Playwright browsers are not installed), so the hint regression script could not complete.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a730dddf28832f969ab87655740b39)