### PR TITLE
fix(export): keep save export limited to game state

### DIFF
--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.22";
+const APP_VERSION = "v0.2.23";
 
 const DEAL_VARIANTS = {
   cells0: {
@@ -1430,20 +1430,7 @@ function exportSave() {
     return;
   }
 
-  let statsHistory = [];
-  try {
-    statsHistory = JSON.parse(localStorage.getItem(STATS_HISTORY_KEY) || '[]');
-  } catch (e) {
-    statsHistory = [];
-  }
-
-  const payload = {
-    version: SAVE_PAYLOAD_VERSION,
-    gameState,
-    statsHistory: Array.isArray(statsHistory) ? statsHistory : []
-  };
-
-  const encoded = btoa(encodeURIComponent(JSON.stringify(payload)));
+  const encoded = btoa(encodeURIComponent(JSON.stringify(gameState)));
   document.getElementById('exportSaveData').value = encoded;
   document.getElementById('modalExport').classList.add('active');
 }
@@ -1514,8 +1501,6 @@ function importSave() {
     const parsed = JSON.parse(decoded);
 
     let gameStateToImport = null;
-    let statsHistoryToImport = [];
-    let importedStats = false;
 
     if (isValidGameState(parsed)) {
       gameStateToImport = parsed;
@@ -1524,17 +1509,14 @@ function importSave() {
         throw new Error("Invalid save format");
       }
       gameStateToImport = parsed.gameState;
-      statsHistoryToImport = sanitizeStatsHistory(parsed.statsHistory);
-      importedStats = statsHistoryToImport.length > 0;
     } else {
       throw new Error("Invalid save format");
     }
 
     applyImportedSaveState(gameStateToImport);
-    localStorage.setItem(STATS_HISTORY_KEY, JSON.stringify(statsHistoryToImport.slice(-MAX_STATS_HISTORY)));
     renderStatsModal();
 
-    alert(`Save imported successfully (${importedStats ? 'game + stats' : 'game only'}).`);
+    alert("Save imported successfully (game only).");
 
   } catch (e) {
     alert("Invalid save data. Please check the code, try pasting again, or use the Copy button.");


### PR DESCRIPTION
## Summary
- update export flow to encode only the current game state payload
- remove stats-history serialization from export to avoid very large save codes
- keep import backward-compatible with older wrapped payloads (`{ gameState, ... }`) but ignore stats data
- adjust import success messaging to clarify that only game data is imported
- bump app version to `v0.2.23`

## Why
Exported save strings had grown excessively large because they bundled long-term stats history in addition to the active game state. This change decouples stats from state so exports remain focused on transferable game progress (including that game's undo history).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7360e5a70832fae56d32eefc46157)