### PR TITLE
build: add Cloudflare Pages full-repo build script

### DIFF
--- a/cloudflare-build.sh
+++ b/cloudflare-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SHORT_SHA=$(printf "%s" "${CF_PAGES_COMMIT_SHA:-local}" | cut -c1-7)
+BASE_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo v0.0.0)
+APP_VERSION="${BASE_TAG}-dev+${SHORT_SHA}"
+
+rm -rf build
+mkdir -p build
+
+# Copy the full repo content to build/ while skipping deployment-irrelevant dirs.
+rsync -a ./ build/ \
+  --exclude '.git' \
+  --exclude 'node_modules' \
+  --exclude 'build'
+
+# Replace version token in common web text assets across the whole site.
+find build -type f \( \
+  -name '*.html' -o \
+  -name '*.js' -o \
+  -name '*.css' -o \
+  -name '*.json' -o \
+  -name '*.txt' -o \
+  -name '*.svg' \
+\) -exec sed -i "s|__APP_VERSION__|${APP_VERSION}|g" {} +

--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.23";
+const APP_VERSION = "v0.2.24";
 
 const DEAL_VARIANTS = {
   cells0: {


### PR DESCRIPTION
## Summary
- add `cloudflare-build.sh` to package the whole repository into `build/` for Cloudflare Pages
- switch from `cp -R` to `rsync` with explicit excludes (`.git`, `node_modules`, `build`) so all website files/folders are copied
- replace `__APP_VERSION__` token across common web text assets (`html/js/css/json/txt/svg`) instead of only `index.html`
- bump in-app semantic version in `index.html` from `v0.2.23` to `v0.2.24` per repo policy

## Cloudflare Pages configuration
Set your **Build command** to:

```bash
./cloudflare-build.sh
```

Set your **Build output directory** to:

```text
build
```

## Notes
- The script computes `APP_VERSION` from latest `v*` tag + short commit SHA and injects it wherever `__APP_VERSION__` appears.
- If no tag exists, it falls back to `v0.0.0`.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a779ee8df4832f954d53b15cfc81cd)