### PR TITLE
fix(hints): handle practical dead-ends consistently

### DIFF
--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.24";
+const APP_VERSION = "v0.2.25";
 
 const DEAL_VARIANTS = {
   cells0: {
@@ -1956,15 +1956,8 @@ function showHint(){
     return;
   }
 
-  const fallbackHintFound = findAnyMove(true, {
-    includeAllCellMoves: true,
-    allowNonPractical: true,
-  });
-
-  if(fallbackHintFound) return;
-
-  announceHint('No practical moves found; try undo/new game.');
-  alert('No practical moves found; try undo/new game.');
+  announceHint('No practical moves remain. Try undo or start a new game.');
+  alert('No practical moves remain. Try undo or start a new game.');
 }
 
 function canFinalizeLoss(){
@@ -2002,6 +1995,11 @@ function checkGameState(){
 
     if(!moveState.hasPracticalMoves){
       announceHint('No practical moves remain. Try undo or start a new game.');
+      setLoseModalContent({
+        title: 'No Practical Moves',
+        message: 'Only loop moves remain. Undo or start a new game.'
+      });
+      document.getElementById('modalLose').classList.add('active');
     }
   }
 }
@@ -2732,6 +2730,40 @@ function runHintRegressionScenario(){
 
   console.assert(cellShuffleMoveState.hasLegalMoves, 'Cell shuffle cycle should still report legal moves.');
   console.assert(!cellShuffleMoveState.hasPracticalMoves, 'Cell shuffle cycle should report no practical progress moves.');
+
+  const previousDeadEndTableau = tableau;
+  const previousDeadEndHand = hand;
+  const previousDeadEndFoundations = foundations;
+  const previousDeadEndRecentMoveContext = recentMoveContext;
+  const previousDeadEndPriorMoveContext = priorMoveContext;
+
+  let deadEndDefaultHintFound = true;
+  let deadEndOptInHintFound = false;
+  let deadEndDetectedAsPracticalDeadEnd = false;
+
+  try {
+    tableau = cellShuffleCycleState.tableau.map(pile => pile.map(card => ({ ...card })));
+    hand = [...cellShuffleCycleState.hand];
+    foundations = cellShuffleCycleState.foundations.map(pile => pile.map(card => ({ ...card })));
+    recentMoveContext = cellShuffleCycleRecentMove;
+    priorMoveContext = null;
+
+    const deadEndMoveState = getMoveAvailabilityState();
+    deadEndDetectedAsPracticalDeadEnd = deadEndMoveState.hasLegalMoves && !deadEndMoveState.hasPracticalMoves;
+
+    deadEndDefaultHintFound = findAnyMove(false);
+    deadEndOptInHintFound = findAnyMove(false, { includeAllCellMoves: true, allowNonPractical: true });
+  } finally {
+    tableau = previousDeadEndTableau;
+    hand = previousDeadEndHand;
+    foundations = previousDeadEndFoundations;
+    recentMoveContext = previousDeadEndRecentMoveContext;
+    priorMoveContext = previousDeadEndPriorMoveContext;
+  }
+
+  console.assert(deadEndDetectedAsPracticalDeadEnd, 'Dead-end state should be reported as legal but not practical by move availability checks.');
+  console.assert(!deadEndDefaultHintFound, 'Dead-end state should not produce a default practical hint suggestion.');
+  console.assert(deadEndOptInHintFound, 'Dead-end state should only expose loop hints through explicit non-practical opt-in.');
 }
 
 
@@ -2748,13 +2780,15 @@ function findAnyMove(highlight, { includeAllCellMoves=false, allowNonPractical=f
   const tier3Moves = legalMoves.filter(move => !isImmediateReverse(move, recentMoveContext, gameState));
   const tier4Moves = legalMoves;
 
-  const candidateMoves = tier1Moves.length
-    ? tier1Moves
-    : tier2Moves.length
-      ? tier2Moves
-      : tier3Moves.length
-        ? tier3Moves
-        : tier4Moves;
+  const candidateMoves = allowNonPractical
+    ? tier1Moves.length
+      ? tier1Moves
+      : tier2Moves.length
+        ? tier2Moves
+        : tier3Moves.length
+          ? tier3Moves
+          : tier4Moves
+    : tier1Moves;
 
   const move = selectHintMove(candidateMoves, { gameState, recentMove: recentMoveContext, priorMove: priorMoveContext });
   if(!move) return false;


### PR DESCRIPTION
### Motivation
- Prevent hints from defaulting to loop-only cell shuffles and make hint/game-state messaging consistent when only non-practical moves remain.
- Ensure the game does not record a loss for legal-but-non-practical (loop-only) states while giving a clear dead-end UX and opt-in fallback for non-practical suggestions.

### Description
- Update `findAnyMove` to honor `allowNonPractical` so default behavior only selects progress-producing (tier-1) candidates and returns `false` at practical dead-ends instead of falling back to loop-only moves.
- Change `showHint()` to avoid auto-falling back to non-practical hints and to announce/alert `No practical moves remain. Try undo or start a new game.` when only non-practical moves exist.
- Add explicit dead-end handling in `checkGameState()` for `hasLegalMoves && !hasPracticalMoves` that surfaces a clear modal (`No Practical Moves`) with Undo/New Game actions while preserving `recordGameResult('loss')` only for true no-legal-moves.
- Extend `runHintRegressionScenario()` with assertions that verify dead-end detection, suppression of default hint suggestions, and opt-in non-practical fallback behavior, and bump `APP_VERSION` from `v0.2.24` to `v0.2.25` in `index.html`.

### Testing
- Ran `git diff --check` and there were no whitespace or diff-check failures.
- Launched a local server with `python3 -m http.server 4173` and validated the dead-end modal rendering via a Playwright script that captured a screenshot (succeeded).
- Exercised the inline `runHintRegressionScenario()` assertions and confirmed the new dead-end assertions (default suppression and opt-in fallback) passed with no assertion failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78e0f7e90832fbf962ab4716ecdf9)