### PR TITLE
fix(build): replace rsync with portable build copy

### DIFF
--- a/cloudflare-build.sh
+++ b/cloudflare-build.sh
@@ -8,11 +8,12 @@ APP_VERSION="${BASE_TAG}-dev+${SHORT_SHA}"
 rm -rf build
 mkdir -p build
 
-# Copy the full repo content to build/ while skipping deployment-irrelevant dirs.
-rsync -a ./ build/ \
-  --exclude '.git' \
-  --exclude 'node_modules' \
-  --exclude 'build'
+# Copy full repo content to build/ using portable tar (rsync is not always available).
+tar -cf - \
+  --exclude='./.git' \
+  --exclude='./node_modules' \
+  --exclude='./build' \
+  . | tar -xf - -C build
 
 # Replace version token in common web text assets across the whole site.
 find build -type f \( \

--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.25";
+const APP_VERSION = "v0.2.26";
 
 const DEAL_VARIANTS = {
   cells0: {


### PR DESCRIPTION
## Summary
- replace `rsync` in `cloudflare-build.sh` with a portable `tar` pipeline to avoid Cloudflare Pages build failures when `rsync` is unavailable
- keep deployment exclusions for `.git`, `node_modules`, and `build`
- bump app patch version in `index.html` from `v0.2.25` to `v0.2.26` per repository versioning rules

## Why
Cloudflare Pages logs showed `rsync: command not found` (exit code `127`) during the build command (`./cloudflare-build.sh`). This change removes that environment dependency while preserving the same artifact-copy behavior.

## Validation
- ran `./cloudflare-build.sh` locally successfully
- confirmed `build/index.html` is generated and carries the updated app version constant

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a790fb8848832f846cbd2dc4fbd1bb)