### PR TITLE
fix(hints): record foundation moves in drag and click paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.26";
+const APP_VERSION = "v0.2.27";
 
 const DEAL_VARIANTS = {
   cells0: {
@@ -3033,6 +3033,13 @@ function commitMove(targetType, targetIdx){
         save(); moveCount++; foundations[targetIdx].push(c);
         if(dragSource.type==='pile'){ tableau[dragSource.idx].pop(); flipTop(dragSource.idx); }
         else hand[dragSource.idx]=null;
+        recordRecentMove(
+          dragSource.type === 'pile' ? 'pile_to_foundation' : 'hand_to_foundation',
+          dragSource.type === 'pile' ? { pileIdx: dragSource.idx, cardIdx: dragSource.cardIdx } : { handIdx: dragSource.idx },
+          { foundationIdx: targetIdx },
+          c
+        );
+        hintHistory = []; // Reset hint history on successful move
         persistGameState();
         success = true;
      }
@@ -3056,6 +3063,13 @@ function cardClick(type, idx, cardIdx){
          save(); moveCount++; foundations[idx].push(c);
          if(selected.type==='pile'){ tableau[selected.idx].pop(); flipTop(selected.idx); }
          else hand[selected.idx]=null;
+         recordRecentMove(
+           selected.type === 'pile' ? 'pile_to_foundation' : 'hand_to_foundation',
+           selected.type === 'pile' ? { pileIdx: selected.idx, cardIdx: selected.cardIdx } : { handIdx: selected.idx },
+           { foundationIdx: idx },
+           c
+         );
+         hintHistory = []; // Reset hint history on successful move
          persistGameState();
          success=true;
        }


### PR DESCRIPTION
## Summary
- add `recordRecentMove(...)` in `commitMove()` when moving a card to foundation via drag-and-drop
- add `recordRecentMove(...)` in `cardClick()` when moving a card to foundation via click-to-move
- reset `hintHistory` in both paths to keep hint anti-loop state aligned with other successful move handlers
- bump app version in `index.html` from `v0.2.26` to `v0.2.27` per repo versioning rules

## Why
`tryFoundation()` already records recent foundation moves, but duplicated foundation logic in drag and click paths skipped this bookkeeping. That caused the anti-loop hint logic to miss those moves.

## Validation
- static inspection of `index.html` confirms foundation success paths in both `commitMove()` and `cardClick()` now mirror the `tryFoundation()` move-recording behavior.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a79cf27590832fbed435b461862669)