### PR TITLE
chore: bump Russian Reserve patch versions

### DIFF
--- a/double_russian_reserve.html
+++ b/double_russian_reserve.html
@@ -925,7 +925,7 @@ const STATS_HISTORY_KEY = "drr_statsHistory_v1";
 const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "drr_dealVariant_v1";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.1.1";
+const APP_VERSION = "v0.1.2";
 
 const DEAL_CONFIG = {
   freeCells: 6,

--- a/index.html
+++ b/index.html
@@ -930,7 +930,7 @@ const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.37";
+const APP_VERSION = "v0.2.38";
 
 const DEAL_VARIANTS = {
   cells0: {


### PR DESCRIPTION
## Summary
- bump Russian Reserve app version in `index.html` from `v0.2.37` to `v0.2.38`
- bump Double Russian Reserve app version in `double_russian_reserve.html` from `v0.1.1` to `v0.1.2`

## Testing
- not run (version-text-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3078fd4dc832fac634d99a6d3e4c2)