### PR TITLE
feat(ui): add interface zoom controls

### DIFF
--- a/double_russian_reserve.html
+++ b/double_russian_reserve.html
@@ -680,6 +680,8 @@ header .controls > *{ flex: 0 0 auto; }
     <div class="header-main">
       <h1>Double Russian Reserve</h1>
       <div class="quick-controls">
+        <button id="zoomOutBtn" onclick="zoomOut()" title="Zoom Out" style="padding: 6px 8px; font-size: 14px; font-family: monospace;">-</button>
+        <button id="zoomInBtn" onclick="zoomIn()" title="Zoom In" style="padding: 6px 8px; font-size: 14px; font-family: monospace;">+</button>
         <button id="hintBtn" onclick="showHint()">Hint</button>
         <button id="undoBtn">Undo</button>
       </div>
@@ -922,10 +924,11 @@ const suitClass = { "♠":"spades", "♥":"hearts", "♦":"diamonds", "♣":"clu
 const SUIT_STYLE_KEY = "drr_suitStyle_v1";
 const GAME_STATE_KEY = "drr_gameState_v1";
 const STATS_HISTORY_KEY = "drr_statsHistory_v1";
+const ZOOM_LEVEL_KEY = "drr_zoomLevel_v1";
 const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "drr_dealVariant_v1";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.1.1";
+const APP_VERSION = "v0.1.2";
 
 const DEAL_CONFIG = {
   freeCells: 6,
@@ -1009,6 +1012,42 @@ let runResultRecorded=false;
 let recentMoveContext = null;
 let priorMoveContext = null;
 let hintHistory = [];
+
+let zoomLevel = 1.0;
+
+function loadZoomLevel() {
+  try {
+    const saved = localStorage.getItem(ZOOM_LEVEL_KEY);
+    if (saved) {
+      const parsed = parseFloat(saved);
+      if (Number.isFinite(parsed) && parsed >= 0.5 && parsed <= 2.5) {
+        zoomLevel = parsed;
+      }
+    }
+  } catch (e) {}
+}
+
+function saveZoomLevel() {
+  try {
+    localStorage.setItem(ZOOM_LEVEL_KEY, zoomLevel.toString());
+  } catch (e) {}
+}
+
+function zoomIn() {
+  if (zoomLevel < 2.5) {
+    zoomLevel += 0.1;
+    saveZoomLevel();
+    scheduleFit();
+  }
+}
+
+function zoomOut() {
+  if (zoomLevel > 0.5) {
+    zoomLevel -= 0.1;
+    saveZoomLevel();
+    scheduleFit();
+  }
+}
 
 let cachedVisitedKeys = null;
 let cachedVisitedKeysState = { moveCount: -1, undoCount: -1 };
@@ -3110,18 +3149,18 @@ function fit(){
   const s = Math.min(1, sW);
 
   // Clamp for usability (phone → desktop). Set a min-width to avoid unplayably tiny cards
-  const w = Math.round(Math.min(120, Math.max(46, baseW * s)));
+  const w = Math.round(Math.min(160, Math.max(34, baseW * s * zoomLevel)));
   const h = Math.round(w * 1.45);
-  let g = Math.round(Math.min(36, Math.max(14, baseGap * s)));
+  let g = Math.round(Math.min(60, Math.max(14, baseGap * s * zoomLevel)));
   // Extra vertical separation on narrow screens so ranks/suits remain readable.
   if (window.innerWidth <= 520) {
-    g = Math.round(Math.min(44, Math.max(18, baseGap * s * 1.25)));
+    g = Math.round(Math.min(68, Math.max(18, baseGap * s * zoomLevel * 1.25)));
   }
   // Big Corner Glyphs need additional overlap clearance.
   if(document.body.classList.contains('suit-style-corners') || document.body.classList.contains('suit-style-cb-corners')){
-    g = Math.round(Math.min(52, g * 1.35));
+    g = Math.round(Math.min(80, g * 1.35));
   }
-  const cg = Math.round(Math.min(12, Math.max(2, baseColGap * s)));
+  const cg = Math.round(Math.min(16, Math.max(2, baseColGap * s * zoomLevel)));
 
   document.documentElement.style.setProperty('--card-w', w + "px");
   document.documentElement.style.setProperty('--card-h', h + "px");
@@ -3176,6 +3215,8 @@ if(isDebugMode){
   console.info('[debug] Hint regression assertions enabled.');
   runHintRegressionScenario();
 }
+
+loadZoomLevel();
 
 const hasImportApplyPending = localStorage.getItem(IMPORT_APPLY_PENDING_KEY) === '1';
 if(hasImportApplyPending){

--- a/index.html
+++ b/index.html
@@ -687,6 +687,8 @@ header .controls > *{ flex: 0 0 auto; }
     <div class="header-main">
       <h1>Russian Reserve</h1>
       <div class="quick-controls">
+        <button id="zoomOutBtn" onclick="zoomOut()" title="Zoom Out" style="padding: 6px 8px; font-size: 14px; font-family: monospace;">-</button>
+        <button id="zoomInBtn" onclick="zoomIn()" title="Zoom In" style="padding: 6px 8px; font-size: 14px; font-family: monospace;">+</button>
         <button id="hintBtn" onclick="showHint()">Hint</button>
         <button id="undoBtn">Undo</button>
       </div>
@@ -926,11 +928,12 @@ const suitClass = { "♠":"spades", "♥":"hearts", "♦":"diamonds", "♣":"clu
 const SUIT_STYLE_KEY = "rs_suitStyle_v1";
 const GAME_STATE_KEY = "rs_gameState_v1";
 const STATS_HISTORY_KEY = "rs_statsHistory_v1";
+const ZOOM_LEVEL_KEY = "rs_zoomLevel_v1";
 const SAVE_PAYLOAD_VERSION = 1;
 const DEAL_VARIANT_KEY = "rs_dealVariant_v1";
 const DEFAULT_DEAL_VARIANT_KEY = "cells3";
 const MAX_STATS_HISTORY = 100000;
-const APP_VERSION = "v0.2.37";
+const APP_VERSION = "v0.2.38";
 
 const DEAL_VARIANTS = {
   cells0: {
@@ -1097,6 +1100,42 @@ let runResultRecorded=false;
 let recentMoveContext = null;
 let priorMoveContext = null;
 let hintHistory = [];
+
+let zoomLevel = 1.0;
+
+function loadZoomLevel() {
+  try {
+    const saved = localStorage.getItem(ZOOM_LEVEL_KEY);
+    if (saved) {
+      const parsed = parseFloat(saved);
+      if (Number.isFinite(parsed) && parsed >= 0.5 && parsed <= 2.5) {
+        zoomLevel = parsed;
+      }
+    }
+  } catch (e) {}
+}
+
+function saveZoomLevel() {
+  try {
+    localStorage.setItem(ZOOM_LEVEL_KEY, zoomLevel.toString());
+  } catch (e) {}
+}
+
+function zoomIn() {
+  if (zoomLevel < 2.5) {
+    zoomLevel += 0.1;
+    saveZoomLevel();
+    scheduleFit();
+  }
+}
+
+function zoomOut() {
+  if (zoomLevel > 0.5) {
+    zoomLevel -= 0.1;
+    saveZoomLevel();
+    scheduleFit();
+  }
+}
 
 let cachedVisitedKeys = null;
 let cachedVisitedKeysState = { moveCount: -1, undoCount: -1 };
@@ -3202,18 +3241,18 @@ function fit(){
   const s = Math.min(1, sW);
 
   // Clamp for usability (phone → desktop).
-  const w = Math.round(Math.min(120, Math.max(34, baseW * s)));
+  const w = Math.round(Math.min(160, Math.max(34, baseW * s * zoomLevel)));
   const h = Math.round(w * 1.45);
-  let g = Math.round(Math.min(36, Math.max(14, baseGap * s)));
+  let g = Math.round(Math.min(60, Math.max(14, baseGap * s * zoomLevel)));
   // Extra vertical separation on narrow screens so ranks/suits remain readable.
   if (window.innerWidth <= 520) {
-    g = Math.round(Math.min(44, Math.max(18, baseGap * s * 1.25)));
+    g = Math.round(Math.min(68, Math.max(18, baseGap * s * zoomLevel * 1.25)));
   }
   // Big Corner Glyphs need additional overlap clearance.
   if(document.body.classList.contains('suit-style-corners') || document.body.classList.contains('suit-style-cb-corners')){
-    g = Math.round(Math.min(52, g * 1.35));
+    g = Math.round(Math.min(80, g * 1.35));
   }
-  const cg = Math.round(Math.min(12, Math.max(2, baseColGap * s)));
+  const cg = Math.round(Math.min(16, Math.max(2, baseColGap * s * zoomLevel)));
 
   document.documentElement.style.setProperty('--card-w', w + "px");
   document.documentElement.style.setProperty('--card-h', h + "px");
@@ -3270,6 +3309,8 @@ if(isDebugMode){
   console.info('[debug] Hint regression assertions enabled.');
   runHintRegressionScenario();
 }
+
+loadZoomLevel();
 
 const hasImportApplyPending = localStorage.getItem(IMPORT_APPLY_PENDING_KEY) === '1';
 if(hasImportApplyPending){

--- a/server.log
+++ b/server.log
@@ -1,3 +1,5 @@
+npm warn exec The following package was not found and will be installed: http-server@14.1.1
+npm warn deprecated whatwg-encoding@2.0.0: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 Starting up http-server, serving .
 
 http-server version: 14.1.1
@@ -17,7 +19,7 @@ Available on:
   http://192.168.0.2:8080
 Hit CTRL-C to stop the server
 
-[2026-03-12T17:47:27.058Z]  "GET /Alaska.html" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.7632.6 Safari/537.36"
-(node:2791) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
+[2026-03-24T02:48:29.830Z]  "GET /index.html" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.7632.6 Safari/537.36"
+(node:2169) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
 (Use `node --trace-deprecation ...` to show where the warning was created)
-[2026-03-12T17:48:09.341Z]  "GET /index.html" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.7632.6 Safari/537.36"
+[2026-03-24T02:48:34.785Z]  "GET /double_russian_reserve.html" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.7632.6 Safari/537.36"


### PR DESCRIPTION
This pull request introduces manual interface zoom controls. Due to varying client default zooming and touch gesture complications, "Zoom In" (`+`) and "Zoom Out" (`-`) buttons were added to the header quick controls. 

The zoom level applies a scaling multiplier to the dynamic grid calculation and is persisted per game variant so users' scaling preferences are remembered on return.

---
*PR created automatically by Jules for task [10871955526707540479](https://jules.google.com/task/10871955526707540479) started by @Rezanow*