### PR TITLE
fix(ui): prevent card rank and suit overlap when zoomed out

### DIFF
--- a/double_russian_reserve.html
+++ b/double_russian_reserve.html
@@ -192,13 +192,13 @@
     }
 
     .val-tl {
-      position: absolute; top: 4px; left: 6px;
-      font-size: clamp(14px, calc(var(--card-w) * 0.25), 20px);
+      position: absolute; top: 3px; left: 3px;
+      font-size: clamp(11px, calc(var(--card-w) * 0.25), 20px);
       font-weight: 700; line-height: 1;
     }
     .suit-tr {
-      position: absolute; top: 4px; right: 6px;
-      font-size: clamp(14px, calc(var(--card-w) * 0.25), 20px);
+      position: absolute; top: 3px; right: 3px;
+      font-size: clamp(11px, calc(var(--card-w) * 0.25), 20px);
       line-height: 1;
     }
     .val-center {
@@ -500,9 +500,9 @@
 
     /* G) Big Corner Glyphs (max clarity without recolor) */
     body.suit-style-corners .val-tl,
-    body.suit-style-cb-corners .val-tl{ font-size: clamp(18px, calc(var(--card-w) * 0.32), 26px); }
+    body.suit-style-cb-corners .val-tl{ font-size: clamp(14px, calc(var(--card-w) * 0.32), 26px); }
     body.suit-style-corners .suit-tr,
-    body.suit-style-cb-corners .suit-tr{ font-size: clamp(18px, calc(var(--card-w) * 0.32), 26px); }
+    body.suit-style-cb-corners .suit-tr{ font-size: clamp(14px, calc(var(--card-w) * 0.32), 26px); }
     body.suit-style-corners .val-center,
     body.suit-style-cb-corners .val-center{ opacity: 0.35; }
 

--- a/index.html
+++ b/index.html
@@ -198,13 +198,13 @@
     }
     
     .val-tl { 
-      position: absolute; top: 4px; left: 6px; 
-      font-size: clamp(14px, calc(var(--card-w) * 0.25), 20px); 
+      position: absolute; top: 3px; left: 3px;
+      font-size: clamp(11px, calc(var(--card-w) * 0.25), 20px);
       font-weight: 700; line-height: 1;
     }
     .suit-tr { 
-      position: absolute; top: 4px; right: 6px; 
-      font-size: clamp(14px, calc(var(--card-w) * 0.25), 20px); 
+      position: absolute; top: 3px; right: 3px;
+      font-size: clamp(11px, calc(var(--card-w) * 0.25), 20px);
       line-height: 1;
     }
     .val-center { 
@@ -506,9 +506,9 @@
 
     /* G) Big Corner Glyphs (max clarity without recolor) */
     body.suit-style-corners .val-tl,
-    body.suit-style-cb-corners .val-tl{ font-size: clamp(18px, calc(var(--card-w) * 0.32), 26px); }
+    body.suit-style-cb-corners .val-tl{ font-size: clamp(14px, calc(var(--card-w) * 0.32), 26px); }
     body.suit-style-corners .suit-tr,
-    body.suit-style-cb-corners .suit-tr{ font-size: clamp(18px, calc(var(--card-w) * 0.32), 26px); }
+    body.suit-style-cb-corners .suit-tr{ font-size: clamp(14px, calc(var(--card-w) * 0.32), 26px); }
     body.suit-style-corners .val-center,
     body.suit-style-cb-corners .val-center{ opacity: 0.35; }
 

--- a/server.log
+++ b/server.log
@@ -19,7 +19,6 @@ Available on:
   http://192.168.0.2:8080
 Hit CTRL-C to stop the server
 
-[2026-03-24T02:48:29.830Z]  "GET /index.html" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.7632.6 Safari/537.36"
-(node:2169) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
+[2026-03-24T03:11:00.416Z]  "GET /index.html" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.7632.6 Safari/537.36"
+(node:2920) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
 (Use `node --trace-deprecation ...` to show where the warning was created)
-[2026-03-24T02:48:34.785Z]  "GET /double_russian_reserve.html" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.7632.6 Safari/537.36"


### PR DESCRIPTION
When zooming out (making cards smaller), the "10" rank was overlapping with the suit symbol due to excessive padding and minimum font sizes that were too large for the compressed horizontal space. This addresses the issue by reducing the left/right absolute positioning from `6px` to `3px` and slightly lowering the minimum font size constraint inside the CSS `clamp()` function.

---
*PR created automatically by Jules for task [10834471078164270815](https://jules.google.com/task/10834471078164270815) started by @Rezanow*