### PR TITLE
feat(dating): expand dating and hangout schedule options to 5 days

### DIFF
--- a/get_conflict_helper.js
+++ b/get_conflict_helper.js
@@ -1,0 +1,19 @@
+setup.get_date_conflict_string = function(day, time, endtime) {
+    if (!V.planneddate) return "";
+    let conflicts = [];
+    for (const date of V.planneddate) {
+        if (date.day == day) {
+            let d_time = date.time || 0;
+            let d_endtime = date.endtime || 24;
+            if (time < d_endtime && endtime > d_time) {
+                let partnerName = date.partner ? (setup.people.can_identify_name(date.partner) ? setup.people.firstname(date.partner) : "someone") : "someone";
+                let activityName = date.activity ? date.activity : "hangout";
+                conflicts.push(activityName + " with " + partnerName);
+            }
+        }
+    }
+    if (conflicts.length > 0) {
+        return " <span class='red'>(Conflict: " + conflicts.join(", ") + ")</span>";
+    }
+    return "";
+}

--- a/patch_inperson.py
+++ b/patch_inperson.py
@@ -1,0 +1,71 @@
+import re
+
+file_path = "CourseOfTemptation.html"
+with open(file_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+# Using find index.
+start_str = "&lt;&lt;set _hour to $proposeddate.time gt 12 ? $proposeddate.time - 12 : $proposeddate.time&gt;&gt;"
+start_idx = content.find(start_str, content.find('name="InPersonDialogueHangoutPlanningTime"'))
+
+never_mind_idx = content.find('&lt;&lt;link &quot;Never mind&quot; InPersonDialogueOngoing&gt;&gt;', start_idx)
+end_idx = content.find('&lt;&lt;/link&gt;&gt;', never_mind_idx) + len('&lt;&lt;/link&gt;&gt;')
+
+if start_idx == -1 or never_mind_idx == -1 or end_idx == -1:
+    print("Cannot find bounds")
+else:
+    print(f"Found bounds! start: {start_idx}, never_mind: {never_mind_idx}, end: {end_idx}")
+
+    replacement = r"""<<set _hour to $proposeddate.time gt 12 ? $proposeddate.time - 12 : $proposeddate.time>>
+    <<for _i to 0; _i lt 5; _i++>>
+        <<if _i eq 0 and $hour gte _todayhour>>
+            <<continue>>
+        <</if>>
+        <<set _targetday to $gameday + _i>>
+        <<set _daylink to (_i eq 0 ? _todaylink : _i eq 1 ? _tomorrowlink : setup.Time.weekday(V.day + _i))>>
+        <<set _conflictstr to setup.get_date_conflict_string(_targetday, $proposeddate.time, $proposeddate.endtime)>>
+        <<capture _i, _targetday, _daylink>>
+        <<link `_daylink + _conflictstr` InPersonDialogueOngoing>>
+            <<set $proposeddate.day to _targetday>>
+            <<set _activityresponse to setup.Relationships.react_to_activity_proposal($proposeddate.partner, $proposeddate.type, _activityinfo, $proposeddate.day)>>
+            <<if !_activityresponse[0]>>
+                <<set $header to '<<anonorfirstnamec $eventnpc>> considers. "' + _activityresponse[1] + '."'>>
+            <<else>>
+                <<if _i eq 0>>
+                    <<if $hour gte _todayhour and $hour lt $proposeddate.endtime>>
+                        <<set $header to '<<anonorfirstnamec $eventnpc>> considers. "Short notice but... sure, I\'m not doing much. '>>
+                    <<else>>
+                        <<set $header to '<<anonorfirstnamec $eventnpc>> considers. "Sure, I can do it anytime after ' + _hour + '. '>>
+                    <</if>>
+                <<elseif _i eq 1>>
+                    <<set $header to '<<anonorfirstnamec $eventnpc>> says, "Sounds great, I\'m free anytime after ' + _hour + '. '>>
+                <<else>>
+                    <<set $header to '<<anonorfirstnamec $eventnpc>> says, "' + _daylink + ' it is! Let\'s plan for sometime after ' + _hour + '. '>>
+                <</if>>
+                <<set _msg to $proposeddate.locmsg>>
+                <<if !/[!.,?]$/.test(_msg)>>
+                    <<set _msg += ".">>
+                <</if>>
+                <<set $header += _msg + '"  <<getnumber $eventnpc>>'>>
+                <<if !$planneddate>>
+                    <<set $planneddate to [$proposeddate]>>
+                <<else>>
+                    <<run $planneddate.push($proposeddate)>>
+                <</if>>
+            <</if>>
+            <<unset $proposeddate>>
+        <</link>><br>
+        <</capture>>
+    <</for>>
+    <<link "Never mind" InPersonDialogueOngoing>>
+        <<set $header to "On second thought, you'll probably be busy. You ask <<po $eventnpc>> to forget you said anything.">>
+        <<unset $proposeddate>>
+    <</link>>"""
+
+    # Replace Twine bracket pairs with html entities to match the surrounding file
+    replacement = replacement.replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;").replace("'", "&#39;")
+
+    new_content = content[:start_idx] + replacement + content[end_idx:]
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(new_content)
+    print("Patched successfully")

--- a/patch_js.py
+++ b/patch_js.py
@@ -1,0 +1,33 @@
+import re
+
+file_path = "CourseOfTemptation.html"
+with open(file_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+helper_function = """
+setup.get_date_conflict_string = function(day, time, endtime) {
+\tif (!V.planneddate) return "";
+\tlet conflicts = [];
+\tfor (const date of V.planneddate) {
+\t\tif (date.day == day) {
+\t\t\tlet d_time = date.time || 0;
+\t\t\tlet d_endtime = date.endtime || 24;
+\t\t\tif (time < d_endtime && endtime > d_time) {
+\t\t\t\tlet partnerName = date.partner ? (setup.people.can_identify_name(date.partner) ? setup.people.firstname(date.partner) : "someone") : "someone";
+\t\t\t\tlet activityName = date.activity ? date.activity : "hangout";
+\t\t\t\tconflicts.push(activityName + " with " + partnerName);
+\t\t\t}
+\t\t}
+\t}
+\tif (conflicts.length > 0) {
+\t\treturn ' <span class="red">(Conflict: ' + conflicts.join(", ") + ')</span>';
+\t}
+\treturn "";
+}
+
+setup.count_dates_planned_for_day = function(day = V.gameday)"""
+
+content = content.replace("setup.count_dates_planned_for_day = function(day = V.gameday)", helper_function)
+
+with open(file_path, "w", encoding="utf-8") as f:
+    f.write(content)

--- a/patch_phone.py
+++ b/patch_phone.py
@@ -1,0 +1,78 @@
+import re
+
+file_path = "CourseOfTemptation.html"
+with open(file_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+start_str = "&lt;&lt;case &quot;hangout time&quot;&gt;&gt;"
+start_idx = content.find(start_str)
+
+end_str = "&lt;&lt;case &quot;send selfie&quot;&gt;&gt;"
+end_idx = content.find(end_str, start_idx)
+
+if start_idx == -1 or end_idx == -1:
+    print("Cannot find bounds")
+else:
+    print(f"Found bounds! start: {start_idx}, end: {end_idx}")
+
+    replacement = r"""<<case "hangout time">>
+                        /* HANGOUT TIME */
+                        <<set _foundday to false>>
+                        <<set _hour to ($proposeddate.time gt 12 ? $proposeddate.time - 12 : $proposeddate.time)>>
+                        <<for _i to 0; _i lt 5; _i++>>
+                            <<if _i eq 0 and $hour gte _todayhour>>
+                                <<continue>>
+                            <</if>>
+                            <<set _targetday to $gameday + _i>>
+                            <<set _daylink to (_i eq 0 ? _todaylink : _i eq 1 ? _tomorrowlink : setup.Time.weekday(V.day + _i))>>
+                            <<set _conflictstr to setup.get_date_conflict_string(_targetday, $proposeddate.time, $proposeddate.endtime)>>
+                            <<capture _i, _targetday, _daylink>>
+                            <<set _foundday to true>>
+                            <<phonelink `_daylink + _conflictstr`>>
+                                <<set _todaysend to _i eq 0 ? _todaysend : _i eq 1 ? "how about tomorrow" : "let's do it " + setup.Time.weekday(V.day + _i).toLowerCase()>>
+                                <<addphonesend _todaysend>>
+                                <<set $proposeddate.day to _targetday>>
+                                <<set _activityresponse to setup.Relationships.react_to_activity_proposal($proposeddate.partner, $proposeddate.type, $proposeddate.activity, $proposeddate.day)>>
+                                <<if !_activityresponse[0]>>
+                                    <<set _msg to setup.people.text_msg($phonetexter, _activityresponse[1])>>
+                                <<else>>
+                                    <<if _i eq 0>>
+                                        <<if $hour gte _todayhour and $hour lt $proposeddate.endtime>>
+                                            <<run _msg.unshift(setup.phone.get_response($proposeddate.partner, "short notice now"))>>
+                                        <<else>>
+                                            <<run _msg.unshift(setup.phone.get_response($proposeddate.partner, "short notice later").replace("%hour", _hour.toString()))>>
+                                        <</if>>
+                                    <<elseif _i eq 1>>
+                                        <<run _msg.unshift(setup.phone.get_response($proposeddate.partner, "agree tomorrow").replace("%hour", _hour.toString()))>>
+                                    <<else>>
+                                        <<set _agreemsg to setup.phone.get_response($proposeddate.partner, "agree " + setup.Time.weekday(V.day + _i).toLowerCase())>>
+                                        <<if !_agreemsg>><<set _agreemsg to setup.phone.get_response($proposeddate.partner, "agree tomorrow")>><</if>>
+                                        <<run _msg.unshift(_agreemsg.replace("%hour", _hour.toString()))>>
+                                    <</if>>
+                                    <<run _msg.push($proposeddate.locmsg)>>
+                                    <<set _msg to setup.people.text_msg($proposeddate.partner, _msg)>>
+                                    <<if !$planneddate>>
+                                        <<set $planneddate to [$proposeddate]>>
+                                    <<else>>
+                                        <<run $planneddate.push($proposeddate)>>
+                                    <</if>>
+                                <</if>>
+                                <<addphonereceive _msg>>
+                                <<phonetextrefresh>>
+                                <<unset $proposeddate>>
+                            <</phonelink>><br>
+                            <</capture>>
+                        <</for>>
+                        <<if !_foundday>>
+                            <<phonelink "You're overbooked..." PhonePlanningOverbooked>>
+                                <<unset $proposeddate>>
+                                <<run setup.close_dialog()>>
+                            <</phonelink>>
+                        <</if>>
+                    """
+
+    replacement = replacement.replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;").replace("'", "&#39;")
+    new_content = content[:start_idx] + replacement + content[end_idx:]
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(new_content)
+    print("Patched successfully")

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,21 @@
+`setup.Time.weekday(day)` takes `$day`, which seems to track the overall day (starting from 1). Wait, `day = V.day`.
+What happens if we do `setup.Time.weekday(V.day + _i)`?
+In Twine, `$day` is the day counter.
+Let's check the implementation of `setup.Time.weekday`:
+```javascript
+setup.Time.weekday = function(day = V.day)
+{
+    day -= 1;
+    while (day > 6) day -= 7;
+    return this.day_of_week[day];
+}
+```
+Yes! It will perfectly wrap if we pass `$day + _i`.
+So we can definitely use `setup.Time.weekday($day + _i)` (or `setup.Time.weekday(V.day + _i)`).
+
+The plan:
+1. Define `setup.get_date_conflict_string(day, time, endtime)` in the JS section of `CourseOfTemptation.html`.
+2. Rewrite `InPersonDialogueHangoutPlanningTime` logic.
+3. Rewrite `PhoneTextingHangout` planning time logic.
+
+Let's do it!

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+console.log("Testing logic")

--- a/update_script.py
+++ b/update_script.py
@@ -1,0 +1,12 @@
+import re
+
+file_path = "CourseOfTemptation.html"
+with open(file_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+# Replace logic in InPersonDialogueHangoutPlanningTime
+search_str = """    <<set _weekday to setup.Time.weekday()>>
+    <<set _plusweekday to ["Friday", "Thursday", "Wednesday", "Tuesday", "Monday"].indexOf(_weekday)>>
+    <<if ["Monday", "Tuesday", "Wednesday"].includes(_weekday) and setup.count_dates_planned_for_day($gameday + _plusweekday) lt 3>>
+        <<link "Friday" InPersonDialogueOngoing>>
+            <<set $proposeddate.day to $gameday + _plusweekday>>"""


### PR DESCRIPTION
Implemented an expanded 5-day date scheduler, replacing the current two-option system for both in-person and phone hangout dialogues. 

- **Conflict Detection:** The system now checks the player's established schedule when proposing a time.
- **Permissive Overbooking:** All 5 choices remain selectable even if conflicting, allowing players to overbook on purpose.
- **Conflict UI:** If a time slot is already taken, a clear conflict text (e.g., "(Conflict: hangout with ...)") appears next to the specific day choice indicating who or what it conflicts with.
- **Interface Update:** The dialogue option link loops have been refactored dynamically to properly render the day offset dynamically across 5 days.

---
*PR created automatically by Jules for task [13512903358929375943](https://jules.google.com/task/13512903358929375943) started by @Rezanow*