### PR TITLE
fix(macros): add missing hint macro to resolve template errors

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,21 +1,13 @@
-`setup.Time.weekday(day)` takes `$day`, which seems to track the overall day (starting from 1). Wait, `day = V.day`.
-What happens if we do `setup.Time.weekday(V.day + _i)`?
-In Twine, `$day` is the day counter.
-Let's check the implementation of `setup.Time.weekday`:
-```javascript
-setup.Time.weekday = function(day = V.day)
-{
-    day -= 1;
-    while (day > 6) day -= 7;
-    return this.day_of_week[day];
-}
-```
-Yes! It will perfectly wrap if we pass `$day + _i`.
-So we can definitely use `setup.Time.weekday($day + _i)` (or `setup.Time.weekday(V.day + _i)`).
+1. **Define the `hint` macro in `CourseOfTemptation.html`**:
+   - Locate the JavaScript section where custom macros are defined (near `Macro.add('debug', ...)`).
+   - Inject a new `Macro.add('hint', ...)` definition that simply wraps its content and evaluates it without requiring any specific settings check, as requested by the user.
 
-The plan:
-1. Define `setup.get_date_conflict_string(day, time, endtime)` in the JS section of `CourseOfTemptation.html`.
-2. Rewrite `InPersonDialogueHangoutPlanningTime` logic.
-3. Rewrite `PhoneTextingHangout` planning time logic.
+2. **Update semantic version in `CourseOfTemptation.html`**:
+   - The file currently has a semantic version that likely looks like `v0.7.8e-Rezanow-Fork` (based on the screenshot).
+   - I will search for this version string and bump the PATCH number (e.g., assuming base version `0.7.8`, I will bump it appropriately based on the exact version found in the HTML file, such as `v0.7.9e-Rezanow-Fork`).
 
-Let's do it!
+3. **Complete pre-commit steps**:
+   - Run verification and checks to ensure proper testing, reviews, and reflection are done.
+
+4. **Submit changes**:
+   - Submit the PR with the title `fix(macros): add missing hint macro to resolve template errors`.


### PR DESCRIPTION
Resolves errors in CourseOfTemptation.html where passages use <<hint>>...<</hint>> tags, but no such macro exists in the SugarCube environment. Defined a simple container macro via Macro.add('hint', { tags: [] }) that evaluates its contents. Also bumped build number in semantic version.

---
*PR created automatically by Jules for task [13458773319868714341](https://jules.google.com/task/13458773319868714341) started by @Rezanow*